### PR TITLE
🔥 Remove different symbols for lume-tooltip

### DIFF
--- a/src/components/core/lume-tooltip/lume-tooltip.vue
+++ b/src/components/core/lume-tooltip/lume-tooltip.vue
@@ -21,10 +21,7 @@
           data-j-tooltip__item
         >
           <span
-            :class="[
-              `lume-tooltip__symbol--${item.type}`,
-              `lume-background-color--${item.color || '01'}`,
-            ]"
+            :class="[`lume-background-color--${item.color}`]"
             class="lume-tooltip__symbol"
             data-j-tooltip__item__symbol
           />
@@ -67,7 +64,6 @@ import { TooltipOptions, useOptions, withOptions } from '@/composables/options';
 import { TOOLTIP_POSITIONS } from '@/constants';
 
 interface TooltipItem {
-  type: string;
   color: string;
   label: string;
   value: number | string;

--- a/src/components/core/lume-tooltip/styles.scss
+++ b/src/components/core/lume-tooltip/styles.scss
@@ -67,10 +67,7 @@ $lume-tooltip-symbol-size: $lume-spacing-10 !default;
     width: $lume-tooltip-symbol-size;
     height: $lume-tooltip-symbol-size;
     flex-shrink: 0;
-
-    &--line {
-      border-radius: 50%;
-    }
+    border-radius: 50%;
   }
 
   &__value {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please pay attention to the following before submitting:
- Read the [Contributing guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md)
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Relates to # <!-- [Relates to / Closes / Fixes] + Github issue # here -->

## 📝 Description

> For v1, tooltips/legend should always show a circle symbol, hence removing the possibility of different symbols.

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

## 📝 Additional Information

>

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
