### PR TITLE
✨ Introduce summary item in LumeTooltip

### DIFF
--- a/src/components/core/lume-tooltip/README.md
+++ b/src/components/core/lume-tooltip/README.md
@@ -64,12 +64,14 @@ Here's an example of overriding the default tooltip in a `lume-line-chart`:
 
 Interface: `TooltipOptions`
 
-| Name             | Type      | Description                                                    |
-| ---------------- | --------- | -------------------------------------------------------------- |
-| offset           | `number`  | Distance between the tooltip and its target element.           |
-| position         | `string`  | Where the tooltip should be positioned relative to its target. |
-| showTitle        | `boolean` | Controls if the tooltip title should be displayed.             |
-| targetElement    | `Element` | A DOM element to attach to.                                    |
-| fixedPositioning | `boolean` | If true, it will use fixed positioning instead of absolute.    |
+| Name             | Type                                                     | Description                                                                                                                             |
+| ---------------- | -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| offset           | `number`                                                 | Distance between the tooltip and its target element.                                                                                    |
+| position         | `string`                                                 | Where the tooltip should be positioned relative to its target.                                                                          |
+| showTitle        | `boolean`                                                | Controls if the tooltip title should be displayed.                                                                                      |
+| targetElement    | `Element`                                                | A DOM element to attach to.                                                                                                             |
+| fixedPositioning | `boolean`                                                | If true, it will use fixed positioning instead of absolute.                                                                             |
+| valueFormat      | `string \| (tick: number \| string) => number \| string` | A format specifier string for [d3-format](https://github.com/d3/d3-format) or a formatting function.                                    |
+| summary          | `string`                                                 | Descriptive text shown above the tooltip items. If a tooltip item is marked with `isSummary`, it will have precedence over this option. |
 
 **Note**: Component properties have precedence over options. For instance, if you set the `targetElement` prop and the `targetElement` tooltip option, the first will be used. They're both there to cover different use cases.

--- a/src/components/core/lume-tooltip/lume-tooltip.spec.ts
+++ b/src/components/core/lume-tooltip/lume-tooltip.spec.ts
@@ -48,4 +48,44 @@ describe('tooltip.vue', () => {
     expect(el.find('[data-j-tooltip__item__label]').text()).toEqual(item.label);
     expect(el.find('[data-j-tooltip__item__value]').text()).toEqual(item.value);
   });
+
+  describe('summary item', () => {
+    test('mount component with summary item from items array', () => {
+      const wrapper = mount(LumeTooltip, {
+        propsData: {
+          items: [{ ...item, isSummary: true }, item],
+          element: mockElement,
+        },
+      });
+
+      const el = wrapper.find('[data-j-tooltip__summary-item]');
+      expect(el.exists()).toBeTruthy();
+    });
+
+    test('mount component with summary item from options', () => {
+      const wrapper = mount(LumeTooltip, {
+        propsData: {
+          items: [item],
+          element: mockElement,
+          options: { summary: 'test summary' },
+        },
+      });
+
+      const el = wrapper.find('[data-j-tooltip__summary-item]');
+      expect(el.exists()).toBeTruthy();
+    });
+
+    test('mount component with summary item from property', () => {
+      const wrapper = mount(LumeTooltip, {
+        propsData: {
+          items: [item],
+          element: mockElement,
+          summary: 'test summary',
+        },
+      });
+
+      const el = wrapper.find('[data-j-tooltip__summary-item]');
+      expect(el.exists()).toBeTruthy();
+    });
+  });
 });

--- a/src/components/core/lume-tooltip/lume-tooltip.vue
+++ b/src/components/core/lume-tooltip/lume-tooltip.vue
@@ -14,6 +14,23 @@
         {{ title }}
       </div>
       <ul class="lume-tooltip__items">
+        <template v-if="summaryItem.label">
+          <li
+            class="lume-tooltip__item"
+            data-j-tooltip__summary-item
+          >
+            <span> {{ summaryItem.label }} </span>
+            <strong
+              v-if="summaryItem.value"
+              class="lume-tooltip__value"
+            >
+              {{ formatValue(summaryItem.value) }}
+            </strong>
+          </li>
+          <li class="lume-tooltip__break">
+            <hr>
+          </li>
+        </template>
         <li
           v-for="item in items"
           :key="item.label"
@@ -65,9 +82,10 @@ import { TooltipOptions, useOptions, withOptions } from '@/composables/options';
 import { TOOLTIP_POSITIONS } from '@/constants';
 
 interface TooltipItem {
-  color: string;
+  color?: string;
   label: string;
-  value: number | string;
+  value?: number | string;
+  isSummary?: true;
 }
 
 export default defineComponent({
@@ -98,12 +116,16 @@ export default defineComponent({
       type: [String, Number],
       default: null,
     },
+    summary: {
+      type: String,
+      default: null,
+    },
     ...withOptions<TooltipOptions>(),
   },
   setup(props) {
     // Refs
     const root = ref<HTMLDivElement>(null);
-    const { options } = toRefs(props);
+    const { items, options } = toRefs(props);
 
     // Data
     const popper: Ref<PopperInstance | null> = ref(null);
@@ -136,9 +158,14 @@ export default defineComponent({
       () => allOptions.value.showTitle !== false && props.title != undefined
     );
 
-    const formatValue = computed(() => {
-      return useFormat(allOptions.value.valueFormat);
-    });
+    const formatValue = computed(() => useFormat(allOptions.value.valueFormat));
+
+    const summaryItem = computed(
+      () =>
+        items.value?.find((item) => item.isSummary) || {
+          label: allOptions.value.summary ?? props.summary,
+        }
+    );
 
     // Methods
     function initPopper() {
@@ -180,6 +207,7 @@ export default defineComponent({
     return {
       allModifiers,
       allOptions,
+      summaryItem,
       formatValue,
       popper,
       root,

--- a/src/components/core/lume-tooltip/styles.scss
+++ b/src/components/core/lume-tooltip/styles.scss
@@ -36,9 +36,18 @@ $lume-tooltip-symbol-size: $lume-spacing-10 !default;
   }
 
   &__title {
-    margin-bottom: $lume-spacing-8;
+    margin-bottom: $lume-spacing-4;
     font-weight: $lume-font-weight-medium;
     color: $lume-tooltip-title-color;
+  }
+
+  &__break {
+    hr {
+      margin-top: $lume-spacing-4;
+      margin-bottom: $lume-spacing-4;
+      border: 0;
+      border-top: 1px solid $lume-color-grey-30;
+    }
   }
 
   &__items {

--- a/src/composables/options.ts
+++ b/src/composables/options.ts
@@ -23,6 +23,7 @@ export interface TooltipOptions extends Options {
   targetElement?: Element | 'self';
   fixedPositioning?: boolean;
   valueFormat?: Format;
+  summary?: string;
 }
 
 type LegendPosition = 'top' | 'bottom';


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please pay attention to the following before submitting:
- Read the [Contributing guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md)
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #102 <!-- [Relates to / Closes / Fixes] + Github issue # here -->

## 📝 Description

> Added an `isSummary` identifier for TooltipItems
> Added a `summary` option to TooltipOptions
> Added a `summary` prop to LumeTooltip

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

## 📝 Additional Information

> `isSummary` takes precedence over `summary` option which takes precedence over `summary` property.

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
