### PR TITLE
🐛 Fix color logic for cases when color is defined in the dataset

### DIFF
--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -46,15 +46,15 @@ function getDivergentColor(color: DivergentColors, index: number) {
 
 function getColorByPalette(color: Color, palette: ColorPalette, index: number) {
   switch (palette) {
-    default:
-    case ColorPalette.Categorical:
-      return isLegacy(color)
-        ? color
-        : getCategoricalColor(color as Colors, index);
-    case ColorPalette.Sequential:
-      return getSequentialColor(color as Colors, index);
-    case ColorPalette.Divergent:
-      return getDivergentColor(color as DivergentColors, index);
+  default:
+  case ColorPalette.Categorical:
+    return isLegacy(color)
+      ? color
+      : getCategoricalColor(color as Colors, index);
+  case ColorPalette.Sequential:
+    return getSequentialColor(color as Colors, index);
+  case ColorPalette.Divergent:
+    return getDivergentColor(color as DivergentColors, index);
   }
 }
 
@@ -65,9 +65,7 @@ export function computeColor(
   index: number
 ) {
   const isDatasetColorValid = validateColor(datasetColor, palette);
-  if (isDatasetColorValid) {
-    return getColorByPalette(datasetColor, palette, index);
-  }
+  if (isDatasetColorValid) return datasetColor;
 
   if (index > 4) {
     warn(Warnings.ColorLoop);


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please pay attention to the following before submitting:
- Read the [Contributing guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md)
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Relates to # <!-- [Relates to / Closes / Fixes] + Github issue # here -->

## 📝 Description

> For cases when user was providing a specific color in the dataset, the color computation was wrong. This fixes it.

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

## 📝 Additional Information

>

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
