### PR TITLE
🧑‍💻 Add commit message check for conventions

### DIFF
--- a/git-hooks/commit-msg
+++ b/git-hooks/commit-msg
@@ -1,0 +1,59 @@
+#!/bin/sh
+
+. ./git-hooks/utils.sh
+
+echo "\n Checking commit structure: \n"
+
+input_file=$1
+
+# message=$(grep "^[^#;+]" $input_file)
+
+# echo $message
+
+index=0
+found_issue_reference=0
+
+while IFS= read -r line
+do
+  if ! [[ $line =~ ^(\#|\;|\+|\-).* ]]; then
+    
+    # Commit subject
+    if [ $index == 0 ]; then
+
+      # TODO: check for gitmoji
+
+      # Commit subject should have < 60 characters
+      if [ ${#line} -gt 60 ]; then
+        echo "\n${RED} ❌ Commit subject line should have less than 60 characters${COLOR_RESET} (This commit has ${#line})\n"
+        exit 1
+      fi
+
+    else
+
+      # Commit message
+
+      # Commit message should have < 100 characters
+      if [ ${#line} -gt 100 ]; then
+        echo "\n${RED} ❌ Commit message lines should have less than 100 characters${COLOR_RESET}\n"
+        exit 1
+      fi
+
+      # Check for issue reference (#number)
+      if [[ $line =~ \#[0-9]+ ]]; then
+        found_issue_reference=1
+      fi
+    fi
+  fi
+
+  index=$((index+1))
+
+done < "$input_file"
+
+if [ $found_issue_reference == 0 ]; then
+  echo "\n${RED} ❌ Commit message doesn't have issue reference${COLOR_RESET}\n"
+  exit 1
+fi
+
+echo "\n${GREEN} ✔ Commit message structure is compliant :)${COLOR_RESET}\n"
+
+exit 0

--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -1,8 +1,6 @@
 #!/bin/sh
 
-RED="\033[1;31m"
-GREEN="\033[1;32m"
-COLOR_RESET="\033[0m"
+. ./git-hooks/utils.sh
 
 linter_exit_code=1
 staged_files_prettier=$(git diff --cached --diff-filter=d --name-only)

--- a/git-hooks/utils.sh
+++ b/git-hooks/utils.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+RED="\033[1;31m"
+GREEN="\033[1;32m"
+COLOR_RESET="\033[0m"


### PR DESCRIPTION
Relates to #124

## 📝 Description

> Added a script to run on Git `commit-msg` hook to check for the defined commit message conventions

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

## 📝 Additional Information

> Moved colors to an utils file to be shared between `commit-msg` and `pre-commit` hooks

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
