### PR TITLE
💚 Fix vitest config

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     threads: false,
     root: 'src',
     include: ['**/*.spec.{js,ts}'],
-    setupFiles: ['./test/config/setupTests.ts'],
+    setupFiles: ['../test/config/setupTests.ts'], // relative to `root` (src)
     environment: 'jsdom',
     coverage: {
       provider: 'istanbul',


### PR DESCRIPTION
## 📝 Description

> Fixes failing test suite caused by upgrading vitest dependency to 0.27.0

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

## 📝 Additional Information

>

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
