### PR TITLE
✨ Add tooltip option to format title

### DIFF
--- a/packages/lib/src/components/core/lume-tooltip/lume-tooltip.spec.ts
+++ b/packages/lib/src/components/core/lume-tooltip/lume-tooltip.spec.ts
@@ -84,6 +84,37 @@ describe('tooltip.vue', () => {
       const el = wrapper.find('[data-j-tooltip__summary-item]');
       expect(el.exists()).toBeTruthy();
     });
+
+    describe('should format title according to options', () => {
+      it('should format title with format string', () => {
+        const wrapper = mount(LumeTooltip, {
+          props: {
+            title: 1234,
+            items: [item],
+            targetElement: mockElement,
+            options: { titleFormat: '~s' },
+          },
+        });
+
+        const titleEl = wrapper.find('[data-j-tooltip__title=""]');
+
+        expect(titleEl.text()).toBe('1.234k');
+      });
+      it('should format title with to function', () => {
+        const wrapper = mount(LumeTooltip, {
+          props: {
+            title,
+            items: [item],
+            targetElement: mockElement,
+            options: { titleFormat: (title) => title + '!' },
+          },
+        });
+
+        const titleEl = wrapper.find('[data-j-tooltip__title=""]');
+
+        expect(titleEl.text()).toBe('My title!');
+      });
+    });
   });
 
   describe('Events API', () => {

--- a/packages/lib/src/components/core/lume-tooltip/lume-tooltip.vue
+++ b/packages/lib/src/components/core/lume-tooltip/lume-tooltip.vue
@@ -12,7 +12,7 @@
         class="lume-tooltip__title"
         data-j-tooltip__title
       >
-        {{ title }}
+        {{ formatTitle(title) }}
       </div>
       <ul class="lume-tooltip__items">
         <template v-if="summaryItem.label">
@@ -166,6 +166,8 @@ const showTitle = computed(
 );
 
 const formatValue = computed(() => useFormat(allOptions.value.valueFormat));
+
+const formatTitle = computed(() => useFormat(allOptions.value.titleFormat));
 
 const summaryItem = computed(
   () =>

--- a/packages/lib/src/composables/options.ts
+++ b/packages/lib/src/composables/options.ts
@@ -20,13 +20,14 @@ export interface AxisOptions extends Options {
 }
 
 export interface TooltipOptions extends Options {
+  fixedPositioning?: boolean;
   offset?: number;
   position?: (typeof TOOLTIP_POSITIONS)[number];
   showTitle?: boolean;
-  targetElement?: Element | 'self';
-  fixedPositioning?: boolean;
-  valueFormat?: Format;
   summary?: string;
+  targetElement?: Element | 'self';
+  titleFormat?: Format;
+  valueFormat?: Format;
 }
 
 type LegendPosition = 'top' | 'bottom';


### PR DESCRIPTION
Closes #180

## 📝 Description

> Added a `tooltipOption` called `titleFormat` that allows users to specify a format string/function for the
> tooltip title

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

## 📝 Additional Information

> --

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
