### PR TITLE
🐛 Hover on the chart is not showing the popover

### DIFF
--- a/packages/lib/src/components/groups/lume-overlay-group/lume-overlay-group.spec.ts
+++ b/packages/lib/src/components/groups/lume-overlay-group/lume-overlay-group.spec.ts
@@ -29,8 +29,8 @@ describe('lume-overlay-group.vue', () => {
 
     const bars = wrapper.findAll('.lume-bar');
 
-    await bars[0].trigger('mouseenter');
-    await bars[2].trigger('mouseenter');
+    await bars[0].trigger('mouseover');
+    await bars[2].trigger('mouseover');
 
     expect(wrapper.emitted()).toHaveProperty('lume__internal--hover');
 

--- a/packages/lib/src/components/groups/lume-overlay-group/lume-overlay-group.vue
+++ b/packages/lib/src/components/groups/lume-overlay-group/lume-overlay-group.vue
@@ -7,7 +7,7 @@
       :data-j-lume-overlay-group="index"
       :transition="false"
       class-list="lume-fill--transparent"
-      @mouseenter="emit('lume__internal--hover', index)"
+      @mouseover="emit('lume__internal--hover', index)"
       @click="emit('click', { index, event: $event })"
     />
   </g>


### PR DESCRIPTION
* lume-bar component was emitting mouseover event, but the parent was listening to mouseenter.

<!---
Thanks for creating a Pull Request 💖!

Please pay attention to the following before submitting:
- Read the [Contributing guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md)
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Relates to #201

## 📝 Description

Tooltips are not coming up when user hovers on line in the line chart and on bars in the bar chart. This issue is occuring only in Vue 2, but this works for Vue 3.

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)


### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
