### PR TITLE
🔖 Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 All notable changes to this project will be documented in this file. Dates are displayed in UTC.
 
+#### [v0.6.0](https://github.com/Adyen/lume/compare/v0.5.3...v0.6.0)
+
+- ✨ Add granular tooltip elements & slot support [`ee46749`](https://github.com/Adyen/lume/commit/ee46749dddca6391de55f49374b2a3cbee1c6dd7)
+- ✨ Introduce hoveredIndex/Element props [`4d227ff`](https://github.com/Adyen/lume/commit/4d227ffb1cdbeeec7db0ec41d6407403d1ddc86d)
+- 📝 Update documentation to reflect hover props [`26b958a`](https://github.com/Adyen/lume/commit/26b958a0fc8dfb0dba556c854eb02f073407327b)
+
 #### [v0.5.3](https://github.com/Adyen/lume/compare/v0.5.2...v0.5.3)
+
+> 9 May 2023
 
 - 🔖 Release v0.5.2 [`a2ed659`](https://github.com/Adyen/lume/commit/a2ed6597f165de0167e387acafb2441fae44b934)
 - 🔖 Release v0.5.3 [`c74e834`](https://github.com/Adyen/lume/commit/c74e834cada8cde34f1f7e5afc30ef317537423f)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adyen/lume",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "Lume is a component library for visual representations of data, built for Vue with D3.",
   "type": "module",
   "workspaces": [

--- a/packages/vue2/package.json
+++ b/packages/vue2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adyen/lume",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "",
   "type": "module",
   "module": "dist/index.js",

--- a/packages/vue3/package.json
+++ b/packages/vue3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adyen/lume-vue3",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "",
   "type": "module",
   "module": "dist/index.js",


### PR DESCRIPTION
- ✨ Add granular tooltip elements & slot support [`ee46749`](https://github.com/Adyen/lume/commit/ee46749dddca6391de55f49374b2a3cbee1c6dd7)
- ✨ Introduce hoveredIndex/Element props [`4d227ff`](https://github.com/Adyen/lume/commit/4d227ffb1cdbeeec7db0ec41d6407403d1ddc86d)
- 📝 Update documentation to reflect hover props [`26b958a`](https://github.com/Adyen/lume/commit/26b958a0fc8dfb0dba556c854eb02f073407327b)
- 🚸 Improve behavior when dataset(s) are empty [`cc8d187`](https://github.com/Adyen/lume/commit/cc8d187f69f17953b4794820d4951a9d9af489c4)
- 🐛 2nd attempt fix paddingOuter issue [`02af784`](https://github.com/Adyen/lume/commit/02af7840693ec6b26087d50b9f315975b95c72d3)
- 🎨 Streamline props for lume-bar-group group component [`307aae7`](https://github.com/Adyen/lume/commit/307aae7a04b5b01d0130fed45764afc5094d5c1b)
- 🐛 2nd attempt fix paddingOuter issue [`976825e`](https://github.com/Adyen/lume/commit/976825eba63ab1c74e3b0895bb9560af26e1fc71)
- 🐛 Fix postbuild script; Bump sass [`1c03841`](https://github.com/Adyen/lume/commit/1c03841841f2684d9200a5bd18856616921c0863)
- ⬆️ Update dependency d3 to v7.8.4 [`a554274`](https://github.com/Adyen/lume/commit/a554274b9be7206efcd2b8c1bdc4f99bed86ad09)
- ⬆️ Update vitest monorepo to ^0.30.0 [`2aa6e88`](https://github.com/Adyen/lume/commit/2aa6e88a666db32c8f9fcfbca7335f8952903039)
- 🩹 Add fallback to isEmpty inject [`0f6e5a8`](https://github.com/Adyen/lume/commit/0f6e5a86bd709d4f6b644997fb77492336f049a6)
- ⬆️ Update dependency vite-plugin-static-copy to ^0.14.0 [`6037853`](https://github.com/Adyen/lume/commit/60378530f97146c6ea5f01546d92ea601e917292)