### PR TITLE
🐛 Fix gradient sizes and nodes that have no color set

### DIFF
--- a/packages/lib/src/components/groups/lume-alluvial-group/composables/alluvial-graph.ts
+++ b/packages/lib/src/components/groups/lume-alluvial-group/composables/alluvial-graph.ts
@@ -3,6 +3,7 @@ import { SankeyLink as D3SankeyLink, sankey, SankeyNode } from 'd3-sankey';
 
 import { AlluvialDiagramOptions } from '@/composables/options';
 
+import { DEFAULT_COLOR } from '@/utils/colors';
 import { Errors, error as logError } from '@/utils/errors';
 import { getAlluvialNodeId } from '../helpers';
 
@@ -34,6 +35,7 @@ export function useAlluvialGraph(
       ({ label, color, value, deriveColorFromIncomingLinks }) => ({
         label: label || value.toString(),
         color,
+        fallbackColor: color || DEFAULT_COLOR,
         id: value,
         deriveColorFromIncomingLinks,
       })

--- a/packages/lib/src/types/alluvial.ts
+++ b/packages/lib/src/types/alluvial.ts
@@ -23,7 +23,8 @@ export interface AlluvialNode extends DatasetValueObject {
 export interface SankeyNodeProps extends SankeyExtraProperties {
   id: number | string;
   label: string;
-  color: Color;
+  color?: Color;
+  fallbackColor: Color;
   transitionValue?: number;
   deriveColorFromIncomingLinks?: boolean;
 }


### PR DESCRIPTION
Fixes #231

## 📝 Description

> Add default (fallback) color upon node computation
> Change gradient generation to generate for each link and map them by link ID

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

## 📝 Additional Information

>

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
