### PR TITLE
🐛 Sparkline transition to read chart option withTransition

### DIFF
--- a/packages/lib/src/components/charts/lume-sparkline-chart/lume-sparkline-chart.vue
+++ b/packages/lib/src/components/charts/lume-sparkline-chart/lume-sparkline-chart.vue
@@ -10,6 +10,9 @@
         v-if="allOptions.showArea"
         :class="[
           'sparkline-chart__area',
+          options.withTransition !== false
+            ? 'sparkline-chart__area--transition'
+            : '',
           `lume-fill--${areaColor || computedColor}`,
           'lume-fill--faded',
         ]"

--- a/packages/lib/src/components/charts/lume-sparkline-chart/lume-sparkline.spec.ts
+++ b/packages/lib/src/components/charts/lume-sparkline-chart/lume-sparkline.spec.ts
@@ -51,6 +51,9 @@ describe('lume-sparkline.vue', () => {
     expect(areaPath.exists()).toBe(true);
     expect(areaPath.classes().includes('lume-fill--faded')).toBe(true);
     expect(areaPath.classes().includes('lume-fill--skyblue')).toBe(true);
+    expect(
+      areaPath.classes().includes('sparkline-chart__area--transition')
+    ).toBe(true);
 
     expect(wrapper.vm.$data).not.toHaveProperty('areaPathDefinition');
   });
@@ -90,5 +93,29 @@ describe('lume-sparkline.vue', () => {
     expect(areaPathDefinition).toBeTruthy();
     expect(areaPathDefinition(xScale, null)).toBeFalsy();
     expect(areaPathDefinition(xScale, yScale)).toBeTruthy();
+  });
+
+  test('transition to be disabled when the withTransition option is set to false', async () => {
+    const wrapper = sparklineChartTestSuiteFactory({
+      data,
+      labels,
+      options: { ...defaultOptions, withTransition: false },
+      xScale,
+    }).run().wrapper;
+
+    const el = wrapper.findComponent(LumeSparkline);
+
+    // We need to trigger a resize for the computed properties to fall into shape
+    const triggerElement = wrapper.find('[data-j-chart-container]');
+    expect(triggerElement.exists()).toBe(true);
+    wrapper.find('[data-j-chart-container]').trigger('resize');
+    await nextTick();
+
+    expect(el.exists()).toBe(true);
+
+    const areaPath = el.find('[data-j-sparkline__area]');
+    expect(
+      areaPath.classes().includes('sparkline-chart__area--transition')
+    ).toBe(false);
   });
 });

--- a/packages/lib/src/components/charts/lume-sparkline-chart/styles.scss
+++ b/packages/lib/src/components/charts/lume-sparkline-chart/styles.scss
@@ -6,6 +6,8 @@ $lume-sparkline-area-opacity: 0.3333 !default;
   &__area {
     pointer-events: none;
     opacity: $lume-sparkline-area-opacity;
-    transition: all $lume-transition-time-long ease;
+    &--transition {
+      transition: all $lume-transition-time-long ease;
+    }
   }
 }


### PR DESCRIPTION
* Disable when chart option 'withTransition' set to false
* Should still have transition, when nothing is set or set to true
* Add tests for transition on sparkline

<!---
Thanks for creating a Pull Request 💖!

Please pay attention to the following before submitting:
- Read the [Contributing guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md)
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Relates to #239 

## 📝 Description

Sparkline transition was not getting disabled, on setting chart option `withTransition` to false

> Add a brief description

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

## 📝 Additional Information

>

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
