### PR TITLE
🔖 Release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,19 @@
 
 All notable changes to this project will be documented in this file. Dates are displayed in UTC.
 
+#### [v0.7.0](https://github.com/Adyen/lume/compare/v0.6.1...v0.7.0)
+
+- ✨ Add support for Alluvial gradient; Add focused state [`b5216da`](https://github.com/Adyen/lume/commit/b5216da755e118e72350f74ef91a5d75049ce7e4)
+- ✨ Include node text slots in Alluvial [`1747e71`](https://github.com/Adyen/lume/commit/1747e7180b27ccdecfc461e2284ad5ff9832af8d)
+- ✨ Allow for custom curve functions in Alluvial links [`3cc5de1`](https://github.com/Adyen/lume/commit/3cc5de16a3412ff9d7717415f6376a5a2546c8c1)
+
 #### [v0.6.1](https://github.com/Adyen/lume/compare/v0.6.0...v0.6.1)
+
+> 20 June 2023
 
 - 🐛 Fix padding handling for all band scales [`8b89cfa`](https://github.com/Adyen/lume/commit/8b89cfa574c53a65cbdd56ce3b74457e181d054a)
 - 🐛 Fix tooltip styles and components exports [`6953100`](https://github.com/Adyen/lume/commit/695310038a66f4a893e20d3c34534d07c6b1897e)
-- 🔖 Release v0.6.0 [`7d24594`](https://github.com/Adyen/lume/commit/7d2459442ada4ae44de45a28f4e626eaddcb3002)
+- 🔖 Release v0.6.1 [`dcba97f`](https://github.com/Adyen/lume/commit/dcba97f7e8b4d8086e703359bd5f0e2f951ccc40)
 
 #### [v0.6.0](https://github.com/Adyen/lume/compare/v0.5.3...v0.6.0)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adyen/lume",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Lume is a component library for visual representations of data, built for Vue with D3.",
   "type": "module",
   "workspaces": [

--- a/packages/vue2/package.json
+++ b/packages/vue2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adyen/lume",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "",
   "type": "module",
   "module": "dist/index.js",

--- a/packages/vue3/package.json
+++ b/packages/vue3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adyen/lume-vue3",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "",
   "type": "module",
   "module": "dist/index.js",


### PR DESCRIPTION
- ✨ Add support for Alluvial gradient; Add focused state [`b5216da`](https://github.com/Adyen/lume/commit/b5216da755e118e72350f74ef91a5d75049ce7e4)
- ✨ Include node text slots in Alluvial [`1747e71`](https://github.com/Adyen/lume/commit/1747e7180b27ccdecfc461e2284ad5ff9832af8d)
- ✨ Allow for custom curve functions in Alluvial links [`3cc5de1`](https://github.com/Adyen/lume/commit/3cc5de16a3412ff9d7717415f6376a5a2546c8c1)
- ✅ Added tests and stories for color derivation [`0b93fc4`](https://github.com/Adyen/lume/commit/0b93fc4a659efc3301e9d0e34558324c315d84c1)
- ✨ Color derivation from incoming links [`2969596`](https://github.com/Adyen/lume/commit/2969596de85b416ff700399c7926278f733f77ca)
- 📝 Add granular components docs; Add to exports [`b422f90`](https://github.com/Adyen/lume/commit/b422f90422a208fd0e5fab93338282166167afda)
- 🐛 Fix gradient sizes and nodes that have no color set [`21f195e`](https://github.com/Adyen/lume/commit/21f195e5c8666e8766b8fa8cd0aa10d662edc954)
- 🐛 Sparkline transition to read chart option withTransition [`ed35981`](https://github.com/Adyen/lume/commit/ed359815176d471d00f1327fcee944f064d65864)
- ✅ Add gradient defs test to Alluvial suite [`65d9dd9`](https://github.com/Adyen/lume/commit/65d9dd9b0f6a4c170abbde8664b84a39af563694)
- 🔧 Update token for Vue3 package publish [`f50c472`](https://github.com/Adyen/lume/commit/f50c4726879b6ded8535ced8672c89af3511db64)
- 🔧 Update token for Vue3 package publish [`9a4a3c4`](https://github.com/Adyen/lume/commit/9a4a3c4ce52917c6dc45ba6b91ae24560708a799)
- 🔧 Update token for Vue3 package publish [`c5c5c7b`](https://github.com/Adyen/lume/commit/c5c5c7be223ea7aca3428c546e7cc6c596adf828)
- ✨ Color derivation from incoming links [`507e8d2`](https://github.com/Adyen/lume/commit/507e8d2557ed6eae1df6cfbca36b8fc8bf0b3492)