### PR TITLE
🐛 Add formatted value to Alluvial node slot

### DIFF
--- a/packages/lib/src/components/charts/lume-alluvial-diagram/README.md
+++ b/packages/lib/src/components/charts/lume-alluvial-diagram/README.md
@@ -182,6 +182,7 @@ interface HighlightedElements {
 
 Available for every node in the diagram. `NODE_ID` is the `value` provided in the dataset.
 
-| Name   | Type                                           | Description    |
-| ------ | ---------------------------------------------- | -------------- |
-| `node` | `SankeyNode<SankeyNodeProps, SankeyLinkProps>` | The node data. |
+| Name    | Type                                           | Description                 |
+| ------- | ---------------------------------------------- | --------------------------- |
+| `node`  | `SankeyNode<SankeyNodeProps, SankeyLinkProps>` | The node data.              |
+| `value` | `number \| string`                             | The node's formatted value. |

--- a/packages/lib/src/components/groups/lume-alluvial-group/lume-alluvial-group.vue
+++ b/packages/lib/src/components/groups/lume-alluvial-group/lume-alluvial-group.vue
@@ -135,6 +135,12 @@
           <slot
             :name="`node-text-${block.node.id}`"
             :node="block.node"
+            :value="
+              formatValue(
+                block.node.transitionValue || block.node.value,
+                block.node.value
+              )
+            "
           >
             <lume-alluvial-node-label>
               {{ block.node.label }}


### PR DESCRIPTION
## 📝 Description

> Added a slot property for the formatted node value

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

## 📝 Additional Information

> In order for consumers to replicate the default node text behavior, we should provide the formatted value as a property.

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
