### PR TITLE
Handling events in lume tooltip

### DIFF
--- a/packages/lib/src/components/charts/lume-bar-chart/lume-bar-chart.stories.ts
+++ b/packages/lib/src/components/charts/lume-bar-chart/lume-bar-chart.stories.ts
@@ -179,8 +179,8 @@ export const CustomTooltip: Story = {
     template: `
     <div :style="{ width: args.width + 'px', height: args.orientation !== 'horizontal' ? args.height + 'px' : undefined }">
         <lume-bar-chart v-bind="args" :color="computedColor">
-          <template #tooltip = "{ data, hoveredIndex, targetElement }">
-            <lume-tooltip :items="customItemsFunction(data, hoveredIndex)" :target-element="targetElement" position="top"/>
+          <template #tooltip = "{ opened, data, hoveredIndex, targetElement }">
+            <lume-tooltip v-if="opened" :items="customItemsFunction(data, hoveredIndex)" :target-element="targetElement" position="top"/>
           </template>
         </lume-bar-chart>
     </div>

--- a/packages/lib/src/components/charts/lume-line-chart/lume-line-chart.stories.ts
+++ b/packages/lib/src/components/charts/lume-line-chart/lume-line-chart.stories.ts
@@ -144,7 +144,7 @@ export const MultipleDatasetsWithCustomTooltip: Story = {
     title: 'Pets met in 2023',
     options: {
       tooltipOptions: {
-        enablePointerEvents: true,
+        withPointerEvents: true,
       },
     },
   },

--- a/packages/lib/src/components/charts/lume-line-chart/lume-line-chart.stories.ts
+++ b/packages/lib/src/components/charts/lume-line-chart/lume-line-chart.stories.ts
@@ -115,8 +115,9 @@ export const MultipleDatasetsWithCustomTooltip: Story = {
     },
     template: `<div :style="{ width: args.width + 'px', height: args.height + 'px' }">
     <lume-line-chart v-bind="args" ${actionEventHandlerTemplate}>
-      <template #tooltip = "{ data, hoveredIndex, targetElement, handleMouseEnter, handleMouseLeave }">
+      <template #tooltip = "{ opened, data, hoveredIndex, targetElement, handleMouseEnter, handleMouseLeave }">
         <lume-tooltip
+          v-if="opened"
           :items="customItemsFunction(data, hoveredIndex)"
           :target-element="targetElement"
           :options="args.options.tooltipOptions"
@@ -144,7 +145,6 @@ export const MultipleDatasetsWithCustomTooltip: Story = {
     options: {
       tooltipOptions: {
         enablePointerEvents: true,
-        withAnimation: false,
       },
     },
   },
@@ -172,8 +172,8 @@ export const CustomTooltip: Story = {
     },
     template: `<div :style="{ width: args.width + 'px', height: args.height + 'px' }">
     <lume-line-chart v-bind="args">
-      <template #tooltip = "{ data, hoveredIndex, targetElement }">
-        <lume-tooltip :items="customItemsFunction(data, hoveredIndex)" :target-element="targetElement" position="top"/>
+      <template #tooltip = "{ opened, data, hoveredIndex, targetElement }">
+        <lume-tooltip v-if="opened" :items="customItemsFunction(data, hoveredIndex)" :target-element="targetElement" position="top"/>
       </template>
     </lume-line-chart>
   </div>`,

--- a/packages/lib/src/components/core/lume-chart/README.md
+++ b/packages/lib/src/components/core/lume-chart/README.md
@@ -233,6 +233,32 @@ No props.
 | `hoveredIndex`  | `number`                  | Index of the data point being hovered.                                                                                             |
 | `options`       | `TooltipOptions`          | Set of options for the tooltip component.                                                                                          |
 
+**Note**: Whenever a consumer overrides the `tooltip` slot in the chart and renders tooltip by themselves - then they have to intimate us when the tooltip is hovered in/out. This has to be done only when the consumer has enabled the pointer events in the tooltip.
+
+This is necessary so that the lume chart is aware when the user has moved inside the tooltip and when was it exited.
+
+`tooltip` slot exposes the props - `handleMouseEnter` and `handleMouseLeave`.
+
+`handleMouseLeave` to be called when the tooltip is hovered in
+`handleMouseLeave` to be called when the tooltip is hovered out
+
+```html
+<lume-line-chart v-bind="args">
+  <template
+    #tooltip="{ opened, data, hoveredIndex, targetElement, handleMouseEnter, handleMouseLeave }"
+  >
+    <lume-tooltip
+      v-if="opened"
+      ...
+      :options="{ withPointerEvents: true }"
+      @tooltip-mouseenter="handleMouseEnter"
+      @tooltip-mouseleave="handleMouseLeave"
+    />
+  </template>
+  ...
+</lume-line-chart>
+```
+
 #### `tooltip-content`
 
 | Name           | Type                      | Description                            |

--- a/packages/lib/src/components/core/lume-chart/lume-chart.spec.ts
+++ b/packages/lib/src/components/core/lume-chart/lume-chart.spec.ts
@@ -178,7 +178,7 @@ describe('lume-chart.vue', () => {
         .find('[data-j-chart-container__root=""]')
         .trigger('mouseleave');
 
-      await retry(() => {
+      await waitFor(() => {
         expect(wrapper.emitted()).toHaveProperty('chart-mouseleave');
         expect(wrapper.emitted()['chart-mouseleave']).toHaveLength(1);
       });

--- a/packages/lib/src/components/core/lume-chart/lume-chart.spec.ts
+++ b/packages/lib/src/components/core/lume-chart/lume-chart.spec.ts
@@ -1,5 +1,4 @@
 import { mount } from '@vue/test-utils';
-
 import LumeChart from './lume-chart.vue';
 
 import { data, labels, xScale, yScale } from '@test/unit/mock-data';
@@ -179,8 +178,10 @@ describe('lume-chart.vue', () => {
         .find('[data-j-chart-container__root=""]')
         .trigger('mouseleave');
 
-      expect(wrapper.emitted()).toHaveProperty('chart-mouseleave');
-      expect(wrapper.emitted()['chart-mouseleave']).toHaveLength(1);
+      await retry(() => {
+        expect(wrapper.emitted()).toHaveProperty('chart-mouseleave');
+        expect(wrapper.emitted()['chart-mouseleave']).toHaveLength(1);
+      });
     });
 
     describe('Events API - Axes, Legend', () => {

--- a/packages/lib/src/components/core/lume-chart/lume-chart.vue
+++ b/packages/lib/src/components/core/lume-chart/lume-chart.vue
@@ -450,8 +450,8 @@ function handleMouseleave() {
   if (shouldHideTooltip.value) {
     hideTooltip();
     internalHoveredIndex.value = -1;
-    emit('chart-mouseleave');
   }
+  emit('chart-mouseleave');
 }
 
 function handleAxisMouseenter({ index, value, event }) {

--- a/packages/lib/src/components/core/lume-chart/lume-chart.vue
+++ b/packages/lib/src/components/core/lume-chart/lume-chart.vue
@@ -192,8 +192,8 @@
         :position="tooltipPosition"
         :with-tooltip="allOptions.withTooltip !== false"
         :hovered-index="internalHoveredIndex"
-        :handle-mouse-enter="() => (hoveredTooltip = true)"
-        :handle-mouse-leave="() => (hoveredTooltip = false)"
+        :handle-mouse-enter="() => (isHoveringTooltip = true)"
+        :handle-mouse-leave="() => (isHoveringTooltip = false)"
         :options="allOptions.tooltipOptions"
       >
         <lume-tooltip
@@ -217,8 +217,8 @@
             })
           "
           @closed="emit('tooltip-closed')"
-          @tooltip-mouseenter="hoveredTooltip = true"
-          @tooltip-mouseleave="hoveredTooltip = false"
+          @tooltip-mouseenter="isHoveringTooltip = true"
+          @tooltip-mouseleave="isHoveringTooltip = false"
         >
           <slot
             name="tooltip-content"
@@ -298,7 +298,7 @@ const internalHoveredIndex = ref<number>(-1);
 const tooltipAnchor = ref<Array<SVGCircleElement>>(null);
 const chartContainer = ref<InstanceType<typeof LumeChartContainer>>(null);
 const tooltipAnchorAttributes = ref<Array<AnchorAttributes>>([]);
-const hoveredTooltip = ref<boolean | null>(null);
+const isHoveringTooltip = ref<boolean | null>(null);
 
 const xAxisHeight = ref<number>(0);
 const yAxisWidth = ref<number>(0);
@@ -411,11 +411,11 @@ const tooltipPosition = computed(
 
 const shouldHideTooltip = computed(() => {
   const arePointerEventsEnabled =
-    allOptions.value.tooltipOptions?.enablePointerEvents;
+    allOptions.value.tooltipOptions?.withPointerEvents;
   return (
     tooltipConfig.opened &&
     (!arePointerEventsEnabled ||
-      (arePointerEventsEnabled && hoveredTooltip.value === false))
+      (arePointerEventsEnabled && isHoveringTooltip.value === false))
   );
 });
 
@@ -498,7 +498,7 @@ watch(
 
 // Handles the scenario when the cursor is already outside of the chart container but in a tooltip and the user
 // tries to leave the tooltip.
-watch(hoveredTooltip, (value) => {
+watch(isHoveringTooltip, (value) => {
   if (value === false && tooltipConfig.opened) {
     handleHideTooltip();
   }

--- a/packages/lib/src/components/core/lume-chart/lume-chart.vue
+++ b/packages/lib/src/components/core/lume-chart/lume-chart.vue
@@ -447,11 +447,13 @@ function handleExternalHover(index: number) {
 }
 
 function handleMouseleave() {
-  if (shouldHideTooltip.value) {
-    hideTooltip();
-    internalHoveredIndex.value = -1;
-  }
-  emit('chart-mouseleave');
+  setTimeout(() => {
+    if (shouldHideTooltip.value) {
+      hideTooltip();
+      internalHoveredIndex.value = -1;
+    }
+    emit('chart-mouseleave');
+  }, 0);
 }
 
 function handleAxisMouseenter({ index, value, event }) {

--- a/packages/lib/src/components/core/lume-tooltip/README.md
+++ b/packages/lib/src/components/core/lume-tooltip/README.md
@@ -125,6 +125,14 @@ p: Element; // The tooltip's new `targetElement` prop value.
 
 Fired upon tooltip unmount.
 
+### `tooltip-mouseenter`
+
+Fired upon mouse entering the lume tooltip.
+
+### `tooltip-mouseleave`
+
+Fired upon mouse leaving the lume tooltip.
+
 ##### Payload
 
 None.

--- a/packages/lib/src/components/core/lume-tooltip/README.md
+++ b/packages/lib/src/components/core/lume-tooltip/README.md
@@ -67,15 +67,16 @@ Here's an example of overriding the default tooltip in a `lume-line-chart`:
 
 Interface: `TooltipOptions`
 
-| Name             | Type                                                     | Description                                                                                                                             |
-| ---------------- | -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| offset           | `number`                                                 | Distance between the tooltip and its target element.                                                                                    |
-| position         | `string`                                                 | Where the tooltip should be positioned relative to its target.                                                                          |
-| showTitle        | `boolean`                                                | Controls if the tooltip title should be displayed.                                                                                      |
-| targetElement    | `Element`                                                | A DOM element to attach to.                                                                                                             |
-| fixedPositioning | `boolean`                                                | If true, it will use fixed positioning instead of absolute.                                                                             |
-| valueFormat      | `string \| (tick: number \| string) => number \| string` | A format specifier string for [d3-format](https://github.com/d3/d3-format) or a formatting function.                                    |
-| summary          | `string`                                                 | Descriptive text shown above the tooltip items. If a tooltip item is marked with `isSummary`, it will have precedence over this option. |
+| Name              | Type                                                     | Description                                                                                                                             |
+| ----------------- | -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| offset            | `number`                                                 | Distance between the tooltip and its target element.                                                                                    |
+| position          | `string`                                                 | Where the tooltip should be positioned relative to its target.                                                                          |
+| showTitle         | `boolean`                                                | Controls if the tooltip title should be displayed.                                                                                      |
+| targetElement     | `Element`                                                | A DOM element to attach to.                                                                                                             |
+| fixedPositioning  | `boolean`                                                | If true, it will use fixed positioning instead of absolute.                                                                             |
+| valueFormat       | `string \| (tick: number \| string) => number \| string` | A format specifier string for [d3-format](https://github.com/d3/d3-format) or a formatting function.                                    |
+| summary           | `string`                                                 | Descriptive text shown above the tooltip items. If a tooltip item is marked with `isSummary`, it will have precedence over this option. |
+| withPointerEvents | `boolean`                                                | If true, it will listen to the attached events on elements in the tooltip content.                                                      |
 
 **Note**: Component properties have precedence over options. For instance, if you set the `targetElement` prop and the `targetElement` tooltip option, the first will be used. They're both there to cover different use cases.
 

--- a/packages/lib/src/components/core/lume-tooltip/lume-tooltip.spec.ts
+++ b/packages/lib/src/components/core/lume-tooltip/lume-tooltip.spec.ts
@@ -142,5 +142,20 @@ describe('tooltip.vue', () => {
       expect(wrapper.emitted()).toHaveProperty('closed');
       expect(wrapper.emitted().closed).toHaveLength(1);
     });
+
+    it('should dispatch `tooltip-mouseenter` when cursor enters nd `tooltip-mouseleave` when cursor leaves the tooltip', async () => {
+      const wrapper = mount(LumeTooltip, { props: defaultProps });
+
+      await wrapper.setProps({ targetElement: document.createElement('div') });
+
+      const el = wrapper.find('[data-j-tooltip]');
+      expect(el.exists()).toBeTruthy();
+
+      await el.trigger('mouseenter');
+      expect(wrapper.emitted()).toHaveProperty('tooltip-mouseenter');
+
+      await el.trigger('mouseleave');
+      expect(wrapper.emitted()).toHaveProperty('tooltip-mouseleave');
+    });
   });
 });

--- a/packages/lib/src/components/core/lume-tooltip/lume-tooltip.vue
+++ b/packages/lib/src/components/core/lume-tooltip/lume-tooltip.vue
@@ -3,7 +3,12 @@
     v-show="targetElement"
     ref="root"
     class="lume-tooltip lume-typography--caption"
+    :class="{
+      'lume-tooltip--pointer-events': options.enablePointerEvents,
+    }"
     data-j-tooltip
+    @mouseenter="emit('tooltip-mouseenter')"
+    @mouseleave="emit('tooltip-mouseleave')"
   >
     <slot>
       <!-- Default chart tooltip content -->
@@ -124,6 +129,8 @@ const emit = defineEmits<{
   (e: 'opened', p: Element);
   (e: 'moved', p: Element);
   (e: 'closed');
+  (e: 'tooltip-mouseenter');
+  (e: 'tooltip-mouseleave');
 }>();
 
 // Refs
@@ -198,7 +205,8 @@ function destroyPopper() {
 function updatePopper() {
   if (!popper.value) return;
 
-  root.value.classList.add('lume-tooltip--animated'); // Add transition class
+  if (allOptions.value.withAnimation !== false)
+    root.value.classList.add('lume-tooltip--animated'); // Add transition class
 
   props.targetElement
     ? (function () {

--- a/packages/lib/src/components/core/lume-tooltip/lume-tooltip.vue
+++ b/packages/lib/src/components/core/lume-tooltip/lume-tooltip.vue
@@ -4,7 +4,7 @@
     ref="root"
     class="lume-tooltip lume-typography--caption"
     :class="{
-      'lume-tooltip--pointer-events': options.enablePointerEvents,
+      'lume-tooltip--pointer-events': options.withPointerEvents,
     }"
     data-j-tooltip
     @mouseenter="emit('tooltip-mouseenter')"

--- a/packages/lib/src/components/core/lume-tooltip/styles.scss
+++ b/packages/lib/src/components/core/lume-tooltip/styles.scss
@@ -36,6 +36,10 @@ $lume-tooltip-symbol-size: $lume-spacing-10 !default;
     transition: transform $lume-transition-time-long ease-out;
   }
 
+  &--pointer-events {
+    pointer-events: auto;
+  }
+
   &__break {
     hr {
       margin-top: $lume-spacing-4;

--- a/packages/lib/src/composables/options.ts
+++ b/packages/lib/src/composables/options.ts
@@ -33,6 +33,8 @@ export interface TooltipOptions extends Options {
   targetElement?: Element | 'self';
   titleFormat?: Format;
   valueFormat?: Format;
+  enablePointerEvents?: boolean;
+  withAnimation?: boolean;
 }
 
 type LegendPosition = 'top' | 'bottom';

--- a/packages/lib/src/composables/options.ts
+++ b/packages/lib/src/composables/options.ts
@@ -33,7 +33,7 @@ export interface TooltipOptions extends Options {
   targetElement?: Element | 'self';
   titleFormat?: Format;
   valueFormat?: Format;
-  enablePointerEvents?: boolean;
+  withPointerEvents?: boolean;
   withAnimation?: boolean;
 }
 

--- a/packages/lib/src/docs/storybook-helpers.ts
+++ b/packages/lib/src/docs/storybook-helpers.ts
@@ -32,6 +32,8 @@ const CHART_EVENTS = [
   'tooltip-opened',
   'tooltip-moved',
   'tooltip-closed',
+  'tooltip-mouseenter',
+  'tooltip-mouseleave',
 ];
 
 export const COLOR_CLASS_MAP = {

--- a/packages/lib/src/types/events.ts
+++ b/packages/lib/src/types/events.ts
@@ -83,6 +83,8 @@ export interface TooltipEvents {
   (e: 'tooltip-opened', p: TooltipEventPayload): void;
   (e: 'tooltip-moved', p: TooltipEventPayload): void;
   (e: 'tooltip-closed'): void;
+  (e: 'tooltip-mouseenter'): void;
+  (e: 'tooltip-mouseleave'): void;
 }
 
 export type ChartEmits = AxisEvents &

--- a/packages/lib/test/config/setupTests.ts
+++ b/packages/lib/test/config/setupTests.ts
@@ -1,7 +1,7 @@
 // Jest cannot find these functionalities natively, so we pad them in as best we need to
 global.ResizeObserver = require('resize-observer-polyfill');
 global.structuredClone = (object) => JSON.parse(JSON.stringify(object));
-global.retry = (assertion, { interval = 20, timeout = 1000 } = {}) => {
+global.waitFor = (assertion, { interval = 20, timeout = 1000 } = {}) => {
   return new Promise((resolve, reject) => {
     const startTime = Date.now();
 

--- a/packages/lib/test/config/setupTests.ts
+++ b/packages/lib/test/config/setupTests.ts
@@ -1,5 +1,22 @@
 // Jest cannot find these functionalities natively, so we pad them in as best we need to
 global.ResizeObserver = require('resize-observer-polyfill');
 global.structuredClone = (object) => JSON.parse(JSON.stringify(object));
+global.retry = (assertion, { interval = 20, timeout = 1000 } = {}) => {
+  return new Promise((resolve, reject) => {
+    const startTime = Date.now();
+
+    const tryAgain = () => {
+      setTimeout(() => {
+        try {
+          resolve(assertion());
+        } catch (err) {
+          Date.now() - startTime > timeout ? reject(err) : tryAgain();
+        }
+      }, interval);
+    };
+
+    tryAgain();
+  });
+};
 
 export {};


### PR DESCRIPTION
Relates to #269 

## 📝 Description

The interaction events within lume tooltip is not captured. This PR aims to provide an option to capture pointer events in tooltip.

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)


### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
