### PR TITLE
🐛 Added support for grouped charts with varied data points.

### DIFF
--- a/packages/lib/src/components/charts/lume-line-chart/lume-line-chart.stories.ts
+++ b/packages/lib/src/components/charts/lume-line-chart/lume-line-chart.stories.ts
@@ -91,7 +91,7 @@ export const MultipleDatasetsWithCustomTooltip: Story = {
         if (hoveredIndex > -1) {
           return data.map((item) => ({
             ...item,
-            value: item.values[hoveredIndex].value,
+            value: item.values[hoveredIndex]?.value ?? 0,
           }));
         }
         return [];
@@ -99,7 +99,7 @@ export const MultipleDatasetsWithCustomTooltip: Story = {
       const computeTotal = (data, hoveredIndex) => {
         if (hoveredIndex > -1) {
           return data.reduce(
-            (acc, current) => acc + current.values[hoveredIndex].value,
+            (acc, current) => acc + (current.values[hoveredIndex]?.value ?? 0),
             0
           );
         }

--- a/packages/lib/src/docs/storybook-data/base-data.ts
+++ b/packages/lib/src/docs/storybook-data/base-data.ts
@@ -163,7 +163,7 @@ const DATASETS = {
   AnimalsMetIn2023: {
     data: [
       {
-        values: [15, 25, 30, null, 40, 50, 60, 12, 30, 12, 344, 400],
+        values: [15, 25, 30, null, 40, 50, 60, 12, 30],
         label: 'Cats',
       },
       {

--- a/packages/lib/src/utils/helpers.spec.ts
+++ b/packages/lib/src/utils/helpers.spec.ts
@@ -112,14 +112,14 @@ describe('helpers.ts', () => {
       expect(t).toThrow('Cannot get highest value from empty array');
     });
 
-    test('should throw an error when index is higher than the length of the datasets', () => {
+    test('should throw an error when index is higher than the length of all the datasets', () => {
       const dataset = [
         { values: [{ value: 1 }, { value: 2 }] },
         { values: [{ value: 3 }, { value: 4 }] },
       ];
       const t = () => getHighestValue(dataset as InternalData, 2);
 
-      expect(t).toThrow('Index exceeds length of at least one of the datasets');
+      expect(t).toThrow('Index exceeds length of all of the datasets');
     });
 
     test('should return 20 as highest found value', () => {

--- a/packages/lib/src/utils/helpers.ts
+++ b/packages/lib/src/utils/helpers.ts
@@ -130,11 +130,12 @@ const validateGetHighestValueArguments = (
     throw new Error('Cannot get highest value from empty array');
   }
 
-  data.forEach(({ values }) => {
-    if (values.length - 1 < index) {
-      throw new Error('Index exceeds length of at least one of the datasets');
-    }
-  });
+  const isIndexPresentInGroup = data.some(
+    ({ values }) => values.length - 1 >= index
+  );
+  if (!isIndexPresentInGroup) {
+    throw new Error('Index exceeds length of all of the datasets');
+  }
 };
 
 /**


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please pay attention to the following before submitting:
- Read the [Contributing guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md)
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Relates to #324 

## 📝 Description

Currently tooltips in grouped chart breaks whenever the number of data points between items in the group are different.

This PR covers:

 - Checking if the data points for atleast one of the item is present before showing the tooltip. If so, the tooltip has to show up.
 - Updated tests and stories to cover this scenario.


> Add a brief description

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)


### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
