### PR TITLE
🔖 Release v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,18 @@
 
 All notable changes to this project will be documented in this file. Dates are displayed in UTC.
 
+#### [1.5.1](https://github.com/Adyen/lume/compare/1.5.0...1.5.1)
+
+- 🔖 Release v1.5.0 [`75feab3`](https://github.com/Adyen/lume/commit/75feab308c6bf2631a46e432a123bade3ba3aaf8)
+- 🐛 Creating tooltip anchors equal to chart labels [`0848177`](https://github.com/Adyen/lume/commit/08481778b73420a035139e4968bc2897231f8ebd)
+
 #### [1.5.0](https://github.com/Adyen/lume/compare/1.4.0...1.5.0)
 
+> 20 November 2023
+
 - ⬆️ Update storybook monorepo to v7.5.2 [`6337521`](https://github.com/Adyen/lume/commit/6337521401e1999303c5d48a3aa539f529252265)
+- 🔖 Release v1.5.0 [`a73838a`](https://github.com/Adyen/lume/commit/a73838ad95180866585802dd5428a6182262d496)
 - ⬆️ Update vue monorepo [`473c633`](https://github.com/Adyen/lume/commit/473c633b0e410cb999bc36330148b83902166fb0)
-- ⬆️ Update dependency webpack to v5.89.0 [`006f790`](https://github.com/Adyen/lume/commit/006f790315bc163e9e0cf5348599c5c835f0757e)
 
 #### [1.4.0](https://github.com/Adyen/lume/compare/1.3.0...1.4.0)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adyen/lume",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Lume is a component library for visual representations of data, built for Vue with D3.",
   "type": "module",
   "license": "MIT",

--- a/packages/vue2/package.json
+++ b/packages/vue2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adyen/lume",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "",
   "type": "module",
   "module": "dist/index.js",

--- a/packages/vue3/package.json
+++ b/packages/vue3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adyen/lume-vue3",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "",
   "type": "module",
   "module": "dist/index.js",


### PR DESCRIPTION
Relates to #324 

## 📝 Description
- Tooltip anchor was not generated for bar charts (grouped/stacked) at points where there was no data in few items of the group.
- Now creating tooltip anchors as many as the chart labels to handle such scenarios.

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
