### PR TITLE
🐛 External hover to check all items before marking index as invalid

### DIFF
--- a/packages/lib/src/components/core/lume-chart/lume-chart.vue
+++ b/packages/lib/src/components/core/lume-chart/lume-chart.vue
@@ -449,7 +449,10 @@ function handleHideTooltip() {
 }
 
 function handleExternalHover(index: number) {
-  if (index > data.value[0].values.length - 1) {
+  const isValidHoveredIndex = data.value.some(
+    ({ values }) => index <= values.length - 1
+  );
+  if (!isValidHoveredIndex) {
     warn(Warnings.InvalidHoveredIndex);
     return;
   }


### PR DESCRIPTION
## 📝 Description
* For grouped charts all the items need not have to be of same length.
* Marking index as invalid only if its greater than all the items.

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

## 📝 Additional Information

>

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
