### PR TITLE
🚸 Replacing the error with warning if index is not present in group.

### DIFF
--- a/packages/lib/src/utils/helpers.spec.ts
+++ b/packages/lib/src/utils/helpers.spec.ts
@@ -112,14 +112,17 @@ describe('helpers.ts', () => {
       expect(t).toThrow('Cannot get highest value from empty array');
     });
 
-    test('should throw an error when index is higher than the length of all the datasets', () => {
+    test('should throw a console warning when index is higher than the length of all the datasets', () => {
+      const warn = vi.spyOn(console, 'warn');
       const dataset = [
         { values: [{ value: 1 }, { value: 2 }] },
         { values: [{ value: 3 }, { value: 4 }] },
       ];
-      const t = () => getHighestValue(dataset as InternalData, 2);
-
-      expect(t).toThrow('Index exceeds length of all of the datasets');
+      getHighestValue(dataset as InternalData, 2);
+      expect(warn).toBeCalledWith(
+        '[lume] Warning: Index exceeds length of all of the datasets'
+      );
+      warn.mockReset();
     });
 
     test('should return 20 as highest found value', () => {

--- a/packages/lib/src/utils/helpers.ts
+++ b/packages/lib/src/utils/helpers.ts
@@ -9,6 +9,7 @@ import {
 } from '@/types/dataset';
 import { Scale } from '@/composables/scales';
 import { Slots } from 'vue/types/v3-setup-context';
+import { warn, Warnings } from '@/utils/warnings';
 
 // Slots from <lume-chart>
 const CHART_SLOTS = [
@@ -134,7 +135,7 @@ const validateGetHighestValueArguments = (
     ({ values }) => values.length - 1 >= index
   );
   if (!isIndexPresentInGroup) {
-    throw new Error('Index exceeds length of all of the datasets');
+    warn(Warnings.IndexExceedsLengthOfDataSets);
   }
 };
 

--- a/packages/lib/src/utils/warnings.ts
+++ b/packages/lib/src/utils/warnings.ts
@@ -15,6 +15,7 @@ export enum Warnings {
   // Hovered index
   InvalidHoveredIndex = 'The provided hovered index is not valid for the data of this chart.',
   InvalidHoveredElement = 'The provided hovered element is not valid for the data of this diagram.',
+  IndexExceedsLengthOfDataSets = 'Index exceeds length of all of the datasets',
 }
 
 const PREFIX = '[lume] ';


### PR DESCRIPTION
## 📝 Description

* When the passed index is greater than ALL the items in the group, we're throwing an error currently.
* But this would result in chart not being rendered - so replacing it with console warning, similar to other hovered index warnings.

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

## 📝 Additional Information

>

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
