### PR TITLE
🐛 Handled missing data in lume charts

### DIFF
--- a/packages/lib/src/components/charts/lume-bar-chart/lume-bar-chart.spec.ts
+++ b/packages/lib/src/components/charts/lume-bar-chart/lume-bar-chart.spec.ts
@@ -9,10 +9,12 @@ import {
   yScale,
 } from '@test/unit/mock-data';
 import { flushPromises } from '@test/unit/flush-promises';
+import { CHART_TYPES, ChartType } from '@/utils/constants';
 
 const numberOfSets = 2;
 const numberOfBars = singleSetData[0].values.length;
 const multiSetData = generateData(numberOfSets, singleSetData[0].values.length);
+const chartType: ChartType = CHART_TYPES.BAR;
 
 const barChartTestSuiteFactory = (props) => new BaseTestSuite(BarChart, props);
 
@@ -23,6 +25,7 @@ describe('lume-bar-chart.vue', () => {
       labels,
       xScale,
       yScale,
+      chartType,
     }).run().wrapper;
 
     await flushPromises();
@@ -36,6 +39,7 @@ describe('lume-bar-chart.vue', () => {
       labels,
       xScale,
       yScale,
+      chartType,
     }).wrapper;
 
     await flushPromises();
@@ -55,6 +59,7 @@ describe('lume-bar-chart.vue', () => {
       labels,
       xScale,
       yScale,
+      chartType,
     }).wrapper;
 
     await flushPromises();
@@ -76,6 +81,7 @@ describe('lume-bar-chart.vue', () => {
       labels,
       xScale,
       yScale,
+      chartType,
     }).wrapper;
 
     await flushPromises();
@@ -91,7 +97,13 @@ describe('lume-bar-chart.vue', () => {
   test.skip('should throw an error when type is not applied for multiset', () => {
     const spy = vi.spyOn(console, 'error').mockImplementation(vi.fn);
     expect(() =>
-      barChartTestSuiteFactory({ data: multiSetData, labels, xScale, yScale })
+      barChartTestSuiteFactory({
+        data: multiSetData,
+        labels,
+        xScale,
+        yScale,
+        chartType,
+      })
     ).toThrowError("Bar chart needs a type when there's multiple datasets.");
     expect(spy).toHaveBeenCalled();
   });

--- a/packages/lib/src/components/charts/lume-grouped-bar-chart/lume-grouped-bar-chart.spec.ts
+++ b/packages/lib/src/components/charts/lume-grouped-bar-chart/lume-grouped-bar-chart.spec.ts
@@ -10,9 +10,10 @@ import {
   yScale,
 } from '@test/unit/mock-data';
 
-import { Orientation } from '@/utils/constants';
+import { CHART_TYPES, ChartType, Orientation } from '@/utils/constants';
 
 const orientation: Orientation = 'horizontal';
+const chartType: ChartType = CHART_TYPES.BAR;
 const numberOfBars = data[0].values.length;
 
 const groupedBarChartTestSuiteFactory = (props) =>
@@ -25,6 +26,7 @@ describe('lume-grouped-bar-chart.vue', () => {
       labels,
       xScale,
       yScale,
+      chartType,
     }).wrapper;
 
     const el = wrapper.find('[data-j-grouped-bar-chart]');
@@ -43,6 +45,7 @@ describe('lume-grouped-bar-chart.vue', () => {
       yScale: xScale,
       xScale: yScale,
       orientation,
+      chartType,
     }).wrapper;
 
     const el = wrapper.findComponent('[data-j-bars-group]');
@@ -60,6 +63,7 @@ describe('lume-grouped-bar-chart.vue', () => {
       labels,
       xScale,
       yScale: linearScale,
+      chartType,
     }).wrapper;
 
     const el = wrapper.findComponent('[data-j-bars-group]');
@@ -79,6 +83,7 @@ describe('lume-grouped-bar-chart.vue', () => {
       yScale: xScale,
       xScale: linearScale,
       orientation,
+      chartType,
     }).wrapper;
 
     const el = wrapper.findComponent('[data-j-bars-group]');
@@ -103,6 +108,7 @@ describe('lume-grouped-bar-chart.vue', () => {
       labels,
       xScale,
       yScale: linearScale,
+      chartType,
     }).wrapper;
 
     const el = wrapper.findComponent('[data-j-bars-group]');
@@ -128,6 +134,7 @@ describe('lume-grouped-bar-chart.vue', () => {
       yScale: xScale,
       xScale: linearScale,
       orientation,
+      chartType,
     }).wrapper;
 
     const el = wrapper.findComponent('[data-j-bars-group]');
@@ -141,6 +148,7 @@ describe('lume-grouped-bar-chart.vue', () => {
     labels,
     xScale,
     yScale,
+    chartType,
   });
   testSuite.run({ selector: '[data-j-lume-bar]', multisetData: [3, 7, 4, 5] });
 });

--- a/packages/lib/src/components/charts/lume-line-chart/lume-line-chart.spec.ts
+++ b/packages/lib/src/components/charts/lume-line-chart/lume-line-chart.spec.ts
@@ -9,8 +9,10 @@ import {
   xScale,
   yScale,
 } from '@test/unit/mock-data';
+import { CHART_TYPES, ChartType } from '@/utils/constants';
 
 const numberOfLines = data[0].values.length;
+const chartType: ChartType = CHART_TYPES.LINE;
 const lineChartTestSuiteFactory = (props) =>
   new BaseTestSuite(LumeLineChart, props);
 
@@ -21,6 +23,7 @@ describe('lume-line-chart.vue', () => {
       labels,
       xScale,
       yScale,
+      chartType,
     }).wrapper;
 
     const el = wrapper.find('[data-j-lume-line-chart]');
@@ -38,6 +41,7 @@ describe('lume-line-chart.vue', () => {
       labels,
       xScale,
       yScale: linearScale,
+      chartType,
     }).wrapper;
 
     const elements = wrapper.findAll('[data-j-line]');
@@ -49,6 +53,7 @@ describe('lume-line-chart.vue', () => {
     labels,
     xScale,
     yScale,
+    chartType,
   });
   testSuite.run({ selector: '[data-j-line]', multisetData: [3, 7, 4, 5] });
 });

--- a/packages/lib/src/components/charts/lume-line-chart/lume-line-chart.stories.ts
+++ b/packages/lib/src/components/charts/lume-line-chart/lume-line-chart.stories.ts
@@ -82,6 +82,22 @@ export const MultipleDatasets: Story = {
   },
 };
 
+export const MultipleDatasetsWithEmptyLabels: Story = {
+  render: ({ args }) => ({
+    components: { LumeLineChart },
+    setup() {
+      return { args, captureAction };
+    },
+    template: `<div :style="{ width: args.width + 'px', height: args.height + 'px' }">
+    <lume-line-chart v-bind="args" ${actionEventHandlerTemplate} />
+</div>`,
+  }),
+  args: {
+    ...DATASETS.AnimalsMetIn2023WithEmptyLabels,
+    title: 'Pets met in 2023',
+  },
+};
+
 export const MultipleDatasetsWithCustomTooltip: Story = {
   render: ({ args }) => ({
     components: { LumeLineChart, LumeTooltip, LumeTooltipSummary },

--- a/packages/lib/src/components/charts/lume-single-bar-chart/lume-single-bar-chart.spec.ts
+++ b/packages/lib/src/components/charts/lume-single-bar-chart/lume-single-bar-chart.spec.ts
@@ -2,10 +2,12 @@ import SingleBarChart from './lume-single-bar-chart.vue';
 
 import { BaseTestSuite } from '@test/unit/reusable.test';
 import { data, labels, xScale, yScale } from '@test/unit/mock-data';
+import { CHART_TYPES, ChartType } from '@/utils/constants';
 
 const numberOfPositiveBars = 5;
 const numberOfNegativeBars = 2;
 const totalNumberOfBars = data[0].values.length;
+const chartType: ChartType = CHART_TYPES.BAR;
 
 const singleBarChartTestSuiteFactory = (props) =>
   new BaseTestSuite(SingleBarChart, props);
@@ -17,6 +19,7 @@ describe('lume-single-bar-chart.vue', () => {
       labels,
       xScale,
       yScale,
+      chartType,
     }).wrapper;
 
     const el = wrapper.find('[data-j-single-bar-chart]');
@@ -47,6 +50,7 @@ describe('lume-single-bar-chart.vue', () => {
       labels,
       xScale,
       yScale,
+      chartType,
     }).wrapper;
 
     const el = wrapper.find('[data-j-single-bar-chart]');
@@ -101,6 +105,7 @@ describe('lume-single-bar-chart.vue', () => {
       labels,
       xScale,
       yScale,
+      chartType,
     }).wrapper;
 
     const el = wrapper.find('[data-j-single-bar-chart]');
@@ -113,6 +118,7 @@ describe('lume-single-bar-chart.vue', () => {
     labels,
     xScale,
     yScale,
+    chartType,
   });
   testSuite.run({ selector: '[data-j-lume-bar]', multisetData: [1, 7, 1, 5] });
 });

--- a/packages/lib/src/components/charts/lume-stacked-bar-chart/lume-stacked-bar-chart.spec.ts
+++ b/packages/lib/src/components/charts/lume-stacked-bar-chart/lume-stacked-bar-chart.spec.ts
@@ -10,9 +10,10 @@ import {
   yScale,
 } from '@test/unit/mock-data';
 
-import { Orientation } from '@/utils/constants';
+import { CHART_TYPES, ChartType, Orientation } from '@/utils/constants';
 
 const orientation: Orientation = 'horizontal';
+const chartType: ChartType = CHART_TYPES.BAR;
 const numberOfBars = data[0].values.length;
 
 const stackedBarChartTestSuiteFactory = (props) =>
@@ -25,6 +26,7 @@ describe('lume-stacked-bar-chart.vue', () => {
       labels,
       xScale,
       yScale,
+      chartType,
     }).wrapper;
 
     const el = wrapper.find('[data-j-stacked-bar-chart]');
@@ -43,6 +45,7 @@ describe('lume-stacked-bar-chart.vue', () => {
       xScale,
       yScale,
       orientation,
+      chartType,
     }).wrapper;
 
     const el = wrapper.findComponent('[data-j-bars-group]');
@@ -59,6 +62,7 @@ describe('lume-stacked-bar-chart.vue', () => {
       labels,
       xScale,
       yScale: manipulatedDataLinearScale,
+      chartType,
     }).wrapper;
 
     const el = wrapper.find('[data-j-bars-group]');
@@ -78,6 +82,7 @@ describe('lume-stacked-bar-chart.vue', () => {
       yScale: xScale,
       xScale: manipulatedDataLinearScale,
       orientation,
+      chartType,
     }).wrapper;
 
     const el = wrapper.find('[data-j-bars-group]');
@@ -102,6 +107,7 @@ describe('lume-stacked-bar-chart.vue', () => {
       labels,
       xScale,
       yScale: manipulatedDataLinearScale,
+      chartType,
     }).wrapper;
 
     const el = wrapper.find('[data-j-bars-group]');
@@ -127,6 +133,7 @@ describe('lume-stacked-bar-chart.vue', () => {
       yScale: xScale,
       xScale: manipulatedDataLinearScale,
       orientation,
+      chartType,
     }).wrapper;
 
     const el = wrapper.find('[data-j-bars-group]');
@@ -140,6 +147,7 @@ describe('lume-stacked-bar-chart.vue', () => {
     labels,
     xScale,
     yScale,
+    chartType,
   });
   testSuite.run({ selector: '[data-j-lume-bar]', multisetData: [3, 7, 4, 5] });
 });

--- a/packages/lib/src/components/charts/lume-stacked-bar-chart/lume-stacked-bar-chart.vue
+++ b/packages/lib/src/components/charts/lume-stacked-bar-chart/lume-stacked-bar-chart.vue
@@ -59,7 +59,7 @@ const { componentEventPropagator } = useEvents(emit);
 
 const slots = excludeGroups(useSlots());
 
-const { data, orientation, options } = toRefs(props);
+const { data, orientation, options, labels } = toRefs(props);
 
 const baseOptions = computed(
   () => defaultOptions[orientation.value || ORIENTATIONS.VERTICAL] // needs to be computed so that default options are reactive
@@ -72,7 +72,7 @@ const { allOptions } = useOptions(
 
 const { internalData } = useBase(data);
 
-const { groupedData } = useBarMixin(internalData);
+const { groupedData } = useBarMixin(internalData, labels);
 
 const { stackedXScaleGenerator, stackedYScaleGenerator } = useStackedAxes(
   groupedData,

--- a/packages/lib/src/components/core/lume-chart/lume-chart.vue
+++ b/packages/lib/src/components/core/lume-chart/lume-chart.vue
@@ -395,10 +395,10 @@ const { shouldGenerateTooltipAnchors } = useTooltipAnchors(
   allOptions,
   computedXScale,
   computedYScale,
+  labels,
   orientation,
   internalData,
-  chartType,
-  labels
+  chartType
 );
 
 const { tooltipConfig, showTooltip, hideTooltip } = useTooltip();

--- a/packages/lib/src/components/groups/lume-bar-group/composables/bar-mixin.ts
+++ b/packages/lib/src/components/groups/lume-bar-group/composables/bar-mixin.ts
@@ -9,6 +9,7 @@ import {
   Orientation,
   ORIENTATIONS,
 } from '@/utils/constants';
+import { fillArrayWithNullValues } from '@/utils/helpers';
 import { DatasetValueObject, InternalData } from '@/types/dataset';
 
 function typeValidator(type: string): boolean {
@@ -36,12 +37,18 @@ export const withBarProps = (useOrientation = false) => ({
     : {}),
 });
 
-export function useBarMixin(data: Ref<InternalData>) {
+export function useBarMixin(
+  data: Ref<InternalData>,
+  labels: Ref<Array<string | number>>
+) {
   /** Array of padded (null = 0) number values */
   const multiBarData: ComputedRef<InternalData> = computed(() => {
     return data.value.map((dataset) => ({
       ...dataset,
-      values: dataset.values.map((datasetValue) => ({
+      values: fillArrayWithNullValues(
+        dataset.values,
+        labels?.value?.length ?? 0
+      ).map((datasetValue) => ({
         ...datasetValue,
         value: datasetValue?.value || 0,
       })),

--- a/packages/lib/src/components/groups/lume-bar-group/lume-bar-group.vue
+++ b/packages/lib/src/components/groups/lume-bar-group/lume-bar-group.vue
@@ -84,13 +84,14 @@ const {
   xScale,
   yScale,
   classList,
+  labels,
 } = toRefs(props);
 
 const chartID = inject<string>('chartID');
 
 const { emitInternalEvent } = useEvents(emit, chartID);
 
-const { groupedData } = useBarMixin(data);
+const { groupedData } = useBarMixin(data, labels);
 
 const { barXScale, barYScale } = useBarScales(xScale, yScale, orientation);
 

--- a/packages/lib/src/components/groups/lume-line-group/lume-line-group.vue
+++ b/packages/lib/src/components/groups/lume-line-group/lume-line-group.vue
@@ -89,7 +89,7 @@ const emit = defineEmits<{
   (e: 'lume__internal--hover', p: number);
 }>();
 
-const { data, options, xScale, yScale } = toRefs(props);
+const { data, options, xScale, yScale, labels } = toRefs(props);
 
 const tooltipAnchorAttributes = inject<Ref<AnchorAttributes[]> | null>(
   'tooltipAnchorAttributes',
@@ -99,7 +99,8 @@ const { updateTooltipAnchorAttributes } = useTooltipAnchors(
   tooltipAnchorAttributes,
   options,
   xScale,
-  yScale
+  yScale,
+  labels
 );
 
 const computedGroupData = computed(() => {

--- a/packages/lib/src/composables/tooltip.spec.ts
+++ b/packages/lib/src/composables/tooltip.spec.ts
@@ -3,7 +3,7 @@ import { mount } from '@vue/test-utils';
 
 import { useTooltip, useTooltipAnchors, useTooltipItems } from './tooltip';
 
-import { data, xScale, yScale } from '@test/unit/mock-data';
+import { data, labels, xScale, yScale } from '@test/unit/mock-data';
 
 import { Orientation } from '@/utils/constants';
 import { InternalData } from '@/types/dataset';
@@ -11,7 +11,13 @@ import { InternalData } from '@/types/dataset';
 const orientation: Orientation = 'vertical';
 const chartType = 'bar';
 
-const getTooltipAnchorsMixin = (anchors, xScale, yScale, orientation) => {
+const getTooltipAnchorsMixin = (
+  anchors,
+  xScale,
+  yScale,
+  labels,
+  orientation
+) => {
   let mixin = null;
   mount({
     template: '<div></div>',
@@ -21,6 +27,7 @@ const getTooltipAnchorsMixin = (anchors, xScale, yScale, orientation) => {
         ref({}),
         ref(xScale),
         ref(yScale),
+        ref(labels),
         ref(orientation),
         ref(data as InternalData),
         ref(chartType)
@@ -54,6 +61,7 @@ describe('tooltip.ts', () => {
         anchors,
         xScale,
         yScale,
+        labels,
         orientation
       );
       mixin.updateTooltipAnchorAttributes(data);
@@ -75,6 +83,7 @@ describe('tooltip.ts', () => {
         anchors,
         yScale,
         xScale,
+        labels,
         'horizontal'
       );
       mixin.updateTooltipAnchorAttributes(data);

--- a/packages/lib/src/composables/tooltip.ts
+++ b/packages/lib/src/composables/tooltip.ts
@@ -3,7 +3,8 @@ import { computed, reactive, Ref, watch } from 'vue';
 import { getXByIndex, Scale } from './scales';
 
 import { NO_DATA, Orientation, ORIENTATIONS } from '@/utils/constants';
-import { DatasetValueObject, InternalData } from '@/types/dataset';
+import { fillArrayWithNullValues } from '@/utils/helpers';
+import { InternalData } from '@/types/dataset';
 import { ChartOptions } from './options';
 
 export interface AnchorAttributes {
@@ -21,28 +22,20 @@ export interface TooltipConfig {
   targetElement: Element | null;
 }
 
-function getFilledArray(
-  originalArray: Array<number | DatasetValueObject>,
-  numberOfLabels: number
-) {
-  const difference = numberOfLabels - originalArray.length;
-  return difference > 0
-    ? [...originalArray, ...Array(difference).fill({ value: null })]
-    : originalArray;
-}
-
 function getHighestValues(data: InternalData, numberOfLabels: number) {
   return data.reduce((acc, curr) => {
-    return getFilledArray(curr.values, numberOfLabels).map((value, index) => {
-      if (!acc[index]) return value.value ?? 0;
-      return value.value > acc[index] ? value.value : acc[index];
-    });
+    return fillArrayWithNullValues(curr.values, numberOfLabels).map(
+      (value, index) => {
+        if (!acc[index]) return value.value ?? 0;
+        return value.value > acc[index] ? value.value : acc[index];
+      }
+    );
   }, [] as Array<number>);
 }
 
 function getStackedHighestValue(data: InternalData, numberOfLabels: number) {
   return data.reduce((acc, curr) => {
-    return getFilledArray(curr.values, numberOfLabels).map(
+    return fillArrayWithNullValues(curr.values, numberOfLabels).map(
       (datasetValue, index) => {
         // Ignore null and negative values
         const value =
@@ -67,10 +60,10 @@ export function useTooltipAnchors(
   options: Ref<ChartOptions>,
   xScale: Ref<Scale>,
   yScale: Ref<Scale>,
+  labels?: Ref<Array<string | number>>,
   orientation?: Ref<Orientation>,
   data?: Ref<InternalData>,
-  chartType?: Ref<string>,
-  labels?: Ref<Array<string>>
+  chartType?: Ref<string>
 ) {
   const shouldGenerateTooltipAnchors = computed(
     () =>

--- a/packages/lib/src/docs/storybook-data/base-data.ts
+++ b/packages/lib/src/docs/storybook-data/base-data.ts
@@ -190,6 +190,32 @@ const DATASETS = {
       'Dec',
     ],
   },
+  AnimalsMetIn2023WithEmptyLabels: {
+    data: [
+      {
+        values: [35, 10, 18, 50, 71, null, 100, 128, 140, 162, 180, 170],
+        label: 'Birds',
+      },
+      {
+        values: [15, 25, 30, null, 40, 50, 60, 12, 30],
+        label: 'Cats',
+      },
+    ],
+    labels: [
+      'Jan',
+      'Feb',
+      'Mar',
+      'Apr',
+      'May',
+      'Jun',
+      'Jul',
+      'Aug',
+      'Sep',
+      '',
+      '',
+      '',
+    ],
+  },
 };
 
 export default DATASETS;

--- a/packages/lib/src/utils/constants.ts
+++ b/packages/lib/src/utils/constants.ts
@@ -123,6 +123,15 @@ export const BAR_TYPES: Record<string, BarType> = {
   STACKED: 'stacked',
 };
 
+export type ChartType = 'bar' | 'line' | 'alluvial' | 'sparkline';
+
+export const CHART_TYPES: Record<string, ChartType> = {
+  BAR: 'bar',
+  LINE: 'line',
+  ALLUVIAL: 'alluvial',
+  SPARKLINE: 'sparkline',
+};
+
 export const NO_DATA = 'No data';
 
 export const BAR_HEIGHT = 20;

--- a/packages/lib/src/utils/helpers.ts
+++ b/packages/lib/src/utils/helpers.ts
@@ -270,3 +270,19 @@ export const nanoid = (n = 21) =>
                 : '_'),
       ''
     );
+/**
+ * Fills the rest of the array with null values if the input array is less than the passed length
+ * @param inputArray The array to be processed
+ * @param minimumOutputArrayLength Minimum length of the returned array
+ * @returns If the input array length is lesser than the passed minimum length, then fills the reminder with null values
+ * Otherwise returns the input array as it is.
+ */
+export function fillArrayWithNullValues(
+  inputArray: Array<number | DatasetValueObject>,
+  minimumOutputArrayLength: number
+) {
+  const difference = minimumOutputArrayLength - inputArray.length;
+  return difference > 0
+    ? [...inputArray, ...Array(difference).fill({ value: null })]
+    : inputArray;
+}

--- a/packages/lib/test/unit/reusable.test.ts
+++ b/packages/lib/test/unit/reusable.test.ts
@@ -4,6 +4,7 @@ import { mount, Wrapper } from '@vue/test-utils';
 import { LumeChart } from '@/components/core';
 
 import { generateData } from './mock-data';
+import { CHART_TYPES } from '@/utils/constants';
 
 type ComponentInstance = VueConstructor;
 type props = Record<string, unknown>;
@@ -46,12 +47,25 @@ export class BaseTestSuite {
 
   public run({ selector, multisetData }: OptionsType = {}): this {
     this.snapShotTest();
-    if (selector) this.multiDataSetTest(selector, ...multisetData);
+    if (selector)
+      this.multiDataSetTest(
+        selector,
+        (this.props.labels as Array<string | number>)?.length ?? 0,
+        this.props.chartType,
+        ...multisetData
+      );
     return this;
+  }
+
+  private getNumberOfRecords(chartType, numberOfLabels, numberOfRecords) {
+    if (chartType === CHART_TYPES.BAR) return numberOfLabels;
+    return numberOfRecords;
   }
 
   private multiDataSetTest(
     targetIdentifier,
+    numberOfLabels,
+    chartType,
     firstNumberOfSets = defaultFirstNumberOfSets,
     firstNumberOfRecords = defaultFirstNumberOfRecords,
     secondNumberOfSets = defaultSecondNumberOfSets,
@@ -67,12 +81,27 @@ export class BaseTestSuite {
     const cases = [
       {
         dataset: firstDataSet,
-        expectedResult: firstNumberOfSets * firstNumberOfRecords,
+        expectedResult:
+          firstNumberOfSets *
+          this.getNumberOfRecords(
+            chartType,
+            numberOfLabels,
+            firstNumberOfRecords
+          ),
       },
-      { dataset: emptyDataSet, expectedResult: 0 },
+      {
+        dataset: emptyDataSet,
+        expectedResult: this.getNumberOfRecords(chartType, numberOfLabels, 0),
+      },
       {
         dataset: secondDataSet,
-        expectedResult: secondNumberOfSets * secondNumberOfRecords,
+        expectedResult:
+          secondNumberOfSets *
+          this.getNumberOfRecords(
+            chartType,
+            numberOfLabels,
+            secondNumberOfRecords
+          ),
       },
     ];
 


### PR DESCRIPTION
## 📝 Description

* Tooltip anchor attributes to be generated for all the data items.
* While grouping the bar chart, index was not considered into account as a result color of items in the group chart were getting messed up when items are not of equal length.

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

## 📝 Additional Information

>

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
