### PR TITLE
🐛 Fix add default value to isEmpty inject

### DIFF
--- a/packages/lib/src/components/core/lume-chart-legend/lume-chart-legend.vue
+++ b/packages/lib/src/components/core/lume-chart-legend/lume-chart-legend.vue
@@ -25,7 +25,7 @@
 </template>
 
 <script setup lang="ts">
-import { ComputedRef, inject, PropType } from 'vue';
+import { inject, PropType, ref, Ref } from 'vue';
 import { InternalData } from '@/types/dataset';
 import { LegendEventPayload } from '@/types/events';
 import { dataValidator } from '@/utils/helpers';
@@ -43,7 +43,7 @@ const emit = defineEmits<{
   (e: 'mouseleave'): void;
 }>();
 
-const isEmpty = inject<ComputedRef<boolean>>('isEmpty');
+const isEmpty = inject<Ref<boolean>>('isEmpty', ref(false));
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
## 📝 Description

> - Fixes a console error when `lume-chart-legend` was used outside of a `lume-chart`

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

## 📝 Additional Information

>

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
