### PR TITLE
🐛 Fix alluvial node min. height in derived nodes

### DIFF
--- a/packages/lib/src/components/groups/lume-alluvial-group/lume-alluvial-group.vue
+++ b/packages/lib/src/components/groups/lume-alluvial-group/lume-alluvial-group.vue
@@ -183,7 +183,11 @@ import { useAlluvialHover } from './composables/alluvial-hover';
 import { DEFAULT_COLOR } from '@/utils/colors';
 import { Color } from '@/utils/constants';
 import { warn, Warnings } from '@/utils/warnings';
-import { GHOST_STROKE_WIDTH_OFFSET, NODE_HEADER_PADDING } from './constants';
+import {
+  GHOST_STROKE_WIDTH_OFFSET,
+  NODE_HEADER_PADDING,
+  NODE_MINIMUM_HEIGHT,
+} from './constants';
 import {
   getLabelSizes,
   getLinkById,
@@ -305,13 +309,26 @@ const nodesDerivingColorFromIncomingLinks = computed(() => {
     linkPaths.value
       .filter(({ link }) => link.target.id === nodeBlock.node.id)
       .reverse()
-      .reduce((accumulatedHeight, currentLinkPath) => {
-        const targetNodeHeight =
-          currentLinkPath.link.target.y1 - currentLinkPath.link.target.y0;
-        const linkRatioOfSourceInTarget =
-          currentLinkPath.link.value / nodeBlock.node.value;
-        const linkHeightOfSourceInTarget =
-          linkRatioOfSourceInTarget * targetNodeHeight;
+      .reduce((accumulatedHeight, currentLinkPath, _i, linksArray) => {
+        const isMinimumHeight =
+          currentLinkPath.link.target.y1 - currentLinkPath.link.target.y0 >
+          NODE_MINIMUM_HEIGHT;
+
+        let targetNodeHeight: number,
+          linkRatioOfSourceInTarget: number,
+          linkHeightOfSourceInTarget: number;
+
+        if (isMinimumHeight) {
+          targetNodeHeight =
+            currentLinkPath.link.target.y1 - currentLinkPath.link.target.y0;
+          linkRatioOfSourceInTarget =
+            currentLinkPath.link.value / nodeBlock.node.value;
+          linkHeightOfSourceInTarget =
+            linkRatioOfSourceInTarget * targetNodeHeight;
+        } else {
+          targetNodeHeight = NODE_MINIMUM_HEIGHT;
+          linkHeightOfSourceInTarget = NODE_MINIMUM_HEIGHT / linksArray.length; // Get ratio from # of links targetting this node
+        }
 
         nodesBasedOnIncomingLinks.push({
           x: nodeBlock.x,


### PR DESCRIPTION

## 📝 Description

> - Added minimum height logic to the nodes deriving color from incoming links

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

## 📝 Additional Information

> - Works by dividing the number of incoming links by the min. node height

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
