### PR TITLE
🐛 Fix unhandled line-group null value cases

### DIFF
--- a/packages/lib/src/components/groups/lume-line-group/lume-line-group.vue
+++ b/packages/lib/src/components/groups/lume-line-group/lume-line-group.vue
@@ -192,7 +192,10 @@ function getPointPosition(pointIndex: number, datasetIndex: number) {
     x: isBandScale(xScale.value)
       ? props.xScale(domain.value[pointIndex]) + xAxisOffset.value
       : props.xScale(pointIndex),
-    y: yScale.value(value),
+    y:
+      value === null
+        ? yScale.value(yScale.value.domain()[1] as number)
+        : yScale.value(value),
   };
 }
 

--- a/packages/lib/src/composables/line-null-values.ts
+++ b/packages/lib/src/composables/line-null-values.ts
@@ -51,6 +51,8 @@ export function useLineNullValues(data: Ref<InternalData>) {
     const step = diff / (length + 1);
     const sum = step * (index + 1);
 
+    if (start == null && end == null) return null;
+
     if (start > end) return start - sum;
     else return start + sum;
   }

--- a/packages/lib/src/composables/line-values.ts
+++ b/packages/lib/src/composables/line-values.ts
@@ -51,5 +51,8 @@ export function getLinePathDefinition(
     )
     .y((d) => yScale(d));
 
+  // Do not calculate path definition if all values are null
+  if (values.every((v) => v == null)) return null;
+
   return lineFn(values);
 }


### PR DESCRIPTION

## 📝 Description

> - Fixed some cases where datasets will all `null` value would cause errors in the console
> - Fixed line group point positioning for all-null datasets

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

## 📝 Additional Information

>

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
