### PR TITLE
🐛 Fix scale override in stacked bar chart

### DIFF
--- a/packages/lib/src/components/charts/lume-stacked-bar-chart/lume-stacked-bar-chart.spec.ts
+++ b/packages/lib/src/components/charts/lume-stacked-bar-chart/lume-stacked-bar-chart.spec.ts
@@ -24,8 +24,6 @@ describe('lume-stacked-bar-chart.vue', () => {
     const wrapper = stackedBarChartTestSuiteFactory({
       data,
       labels,
-      xScale,
-      yScale,
       chartType,
     }).wrapper;
 
@@ -42,8 +40,6 @@ describe('lume-stacked-bar-chart.vue', () => {
     const wrapper = stackedBarChartTestSuiteFactory({
       data,
       labels,
-      xScale,
-      yScale,
       orientation,
       chartType,
     }).wrapper;
@@ -60,7 +56,6 @@ describe('lume-stacked-bar-chart.vue', () => {
     const wrapper = stackedBarChartTestSuiteFactory({
       data: manipulatedData,
       labels,
-      xScale,
       yScale: manipulatedDataLinearScale,
       chartType,
     }).wrapper;
@@ -105,7 +100,6 @@ describe('lume-stacked-bar-chart.vue', () => {
     const wrapper = stackedBarChartTestSuiteFactory({
       data: manipulatedData,
       labels,
-      xScale,
       yScale: manipulatedDataLinearScale,
       chartType,
     }).wrapper;
@@ -145,8 +139,6 @@ describe('lume-stacked-bar-chart.vue', () => {
   const testSuite = stackedBarChartTestSuiteFactory({
     data: [{ values: [] }],
     labels,
-    xScale,
-    yScale,
     chartType,
   });
   testSuite.run({ selector: '[data-j-lume-bar]', multisetData: [3, 7, 4, 5] });

--- a/packages/lib/src/components/charts/lume-stacked-bar-chart/lume-stacked-bar-chart.vue
+++ b/packages/lib/src/components/charts/lume-stacked-bar-chart/lume-stacked-bar-chart.vue
@@ -3,8 +3,8 @@
     v-bind="props"
     chart-type="stacked-bar"
     :options="allOptions"
-    :x-scale="stackedXScaleGenerator"
-    :y-scale="stackedYScaleGenerator"
+    :x-scale="xScale"
+    :y-scale="yScale"
     data-j-stacked-bar-chart
     v-on="componentEventPropagator"
   >
@@ -79,4 +79,8 @@ const { stackedXScaleGenerator, stackedYScaleGenerator } = useStackedAxes(
   orientation,
   options
 );
+
+// Allow for prop override
+const xScale = computed(() => props.xScale || stackedXScaleGenerator);
+const yScale = computed(() => props.yScale || stackedYScaleGenerator);
 </script>


### PR DESCRIPTION
Fixes #374

## 📝 Description

> - Added computed scales for stacked bar chart that allow for prop override

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

## 📝 Additional Information

>

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
