### PR TITLE
🐛 Show chart legend even if values are empty

### DIFF
--- a/packages/lib/src/components/core/lume-chart-legend/lume-chart-legend.vue
+++ b/packages/lib/src/components/core/lume-chart-legend/lume-chart-legend.vue
@@ -1,6 +1,5 @@
 <template>
   <div
-    v-if="!isEmpty"
     class="lume-chart-legend"
     data-j-chart-legend
     @mouseleave="emit('mouseleave')"
@@ -25,7 +24,7 @@
 </template>
 
 <script setup lang="ts">
-import { inject, PropType, ref, Ref } from 'vue';
+import { PropType } from 'vue';
 import { InternalData } from '@/types/dataset';
 import { LegendEventPayload } from '@/types/events';
 import { dataValidator } from '@/utils/helpers';
@@ -42,8 +41,6 @@ const emit = defineEmits<{
   (e: 'click' | 'mouseenter', p: LegendEventPayload): void;
   (e: 'mouseleave'): void;
 }>();
-
-const isEmpty = inject<Ref<boolean>>('isEmpty', ref(false));
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
Closes #373

## 📝 Description

> Removed `v-if="!isEmpty"` in `lume-chart-legend`

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

## 📝 Additional Information

>

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
