### PR TITLE
🐛 Fix wrong assumption on external hover

### DIFF
--- a/packages/lib/src/components/core/lume-chart/lume-chart.vue
+++ b/packages/lib/src/components/core/lume-chart/lume-chart.vue
@@ -457,7 +457,12 @@ function handleExternalHover(index: number) {
     return;
   }
 
-  handleInternalHover(index);
+  // If external index is null/undefined or -1, should hide
+  if (index == null || index === -1) {
+    handleHideTooltip();
+  } else {
+    handleInternalHover(index);
+  }
 }
 
 function handleMouseleave() {

--- a/packages/lib/src/playground/synced-tooltip.stories.ts
+++ b/packages/lib/src/playground/synced-tooltip.stories.ts
@@ -1,0 +1,81 @@
+import { ref } from 'vue';
+import type { Meta, StoryObj } from '@storybook/vue3';
+
+import { withSizeArgs, withSizeArgTypes } from '@/docs/storybook-helpers';
+import DATASETS from '@/docs/storybook-data/base-data';
+
+import LumeBarChart from '../components/charts/lume-bar-chart';
+
+const meta: Meta<typeof LumeBarChart> = {
+  title: 'Playground/Synced tooltips',
+  component: LumeBarChart,
+  argTypes: {
+    ...withSizeArgTypes(),
+    data: {
+      control: 'object',
+      description: 'Chart data.',
+    },
+    labels: {
+      control: 'object',
+      description: 'Chart labels.',
+    },
+    hoveredIndex: {
+      control: 'number',
+      description: 'Chart hovered index',
+    },
+  },
+  args: {
+    ...withSizeArgs(),
+    options: {
+      margins: 'auto',
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof LumeBarChart>;
+
+export const Basic: Story = {
+  render: ({ args }) => ({
+    components: { LumeBarChart },
+    setup() {
+      const containerStyle = {
+        width: '480px',
+        height: '320px',
+        padding: '8px',
+        border: '1px solid var(--lume-color--grey-50)',
+        borderRadius: '4px',
+        overflow: 'hidden',
+      };
+      const hoveredIndex = ref(-1);
+      return { args, containerStyle, hoveredIndex };
+    },
+    template: `
+    <div :style="containerStyle" style="margin-bottom: 16px">
+        <lume-bar-chart
+            v-bind="args"
+            type="stacked"
+            :hovered-index="hoveredIndex"
+            @tooltip-opened="hoveredIndex = $event.index"
+            @tooltip-moved="hoveredIndex = $event.index"
+            @tooltip-closed="hoveredIndex = -1"
+        />
+    </div>
+    <div :style="containerStyle">
+        <lume-bar-chart
+            v-bind="args"
+            type="stacked"
+            :hovered-index="hoveredIndex"
+            @tooltip-opened="hoveredIndex = $event.index"
+            @tooltip-moved="hoveredIndex = $event.index"
+            @tooltip-closed="hoveredIndex = -1"
+        />
+    </div>
+    `,
+  }),
+  args: {
+    ...DATASETS.AnimalsMetIn2023,
+    title: 'Synced tooltips',
+  },
+};


### PR DESCRIPTION
## 📝 Description

Before, when trying to sync tooltips between two charts (like the example below), one of them would fly in instead of appear in the chart.

```vue
<lume-bar-chart
    v-bind="args"
    type="stacked"
    :hovered-index="hoveredIndex"
    @tooltip-opened="hoveredIndex = $event.index"
    @tooltip-moved="hoveredIndex = $event.index"
    @tooltip-closed="hoveredIndex = -1"
/>
<lume-bar-chart
    v-bind="args"
    type="stacked"
    :hovered-index="hoveredIndex"
    @tooltip-opened="hoveredIndex = $event.index"
    @tooltip-moved="hoveredIndex = $event.index"
    @tooltip-closed="hoveredIndex = -1"
/>
```

This was because the `handleExternalHover` in `<lume-chart>` was always calling `handleInternalHover` even if the external index was `-1` (or `null`).

This PR corrects that into checking if it should handle it as show or hide tooltip based on the provided index.

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

## 📝 Additional Information

- Added a Storybook Playground example of synced tooltips

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
