### PR TITLE
✨ Introduce inverse property/option in lume-tooltip

### DIFF
--- a/packages/lib/src/components/charts/lume-stacked-bar-chart/defaults.ts
+++ b/packages/lib/src/components/charts/lume-stacked-bar-chart/defaults.ts
@@ -7,12 +7,13 @@ export const options = {
     xAxisOptions: {},
     yAxisOptions: { gridLines: true },
     margins: DEFAULT_MARGINS.VERTICAL,
+    tooltipOptions: { inverse: true },
   },
   [ORIENTATIONS.HORIZONTAL]: {
     withTooltip: true,
     xAxisOptions: { gridLines: true },
     yAxisOptions: { gridLines: false },
     margins: DEFAULT_MARGINS.HORIZONTAL,
-    tooltipOptions: { position: 'right' },
+    tooltipOptions: { position: 'right', inverse: true },
   },
 };

--- a/packages/lib/src/components/core/lume-tooltip/README.md
+++ b/packages/lib/src/components/core/lume-tooltip/README.md
@@ -59,6 +59,7 @@ Here's an example of overriding the default tooltip in a `lume-line-chart`:
 | `fixedPositioning` | `boolean`            | `false`  | If true, it will use fixed positioning instead of absolute.    |
 | `modifiers`        | `Array<Modifier>`    | `null`   | A list of modifiers for Popper.                                |
 | `title`            | `string`             | `null`   | The tooltip title.                                             |
+| `inverse`          | `boolean`            | `false`  | If true, the tooltip items will be in inverse order.           |
 
 **Note**: the `position` prop only accepts valid placements. These are specified [here](https://popper.js.org/docs/v2/constructors/#options).
 **Note**: You can find more information about modifiers [here](https://popper.js.org/docs/v2/modifiers/).
@@ -77,6 +78,7 @@ Interface: `TooltipOptions`
 | valueFormat       | `string \| (tick: number \| string) => number \| string` | A format specifier string for [d3-format](https://github.com/d3/d3-format) or a formatting function.                                    |
 | summary           | `string`                                                 | Descriptive text shown above the tooltip items. If a tooltip item is marked with `isSummary`, it will have precedence over this option. |
 | withPointerEvents | `boolean`                                                | If true, it will listen to the attached events on elements in the tooltip content.                                                      |
+| inverse           | `boolean`                                                | If true, the tooltip items will be in inverse order.                                                                                    |
 
 **Note**: Component properties have precedence over options. For instance, if you set the `targetElement` prop and the `targetElement` tooltip option, the first will be used. They're both there to cover different use cases.
 

--- a/packages/lib/src/components/core/lume-tooltip/lume-tooltip.spec.ts
+++ b/packages/lib/src/components/core/lume-tooltip/lume-tooltip.spec.ts
@@ -4,16 +4,22 @@ import LumeTooltip from './lume-tooltip.vue';
 
 const title = 'My title';
 const mockElement = document.createElement('div');
-const item = {
+const item1 = {
   type: 'my-type',
   color: '02',
   label: 'my-label',
   value: 'my-value',
 };
+const item2 = {
+  type: 'my-type-2',
+  color: '03',
+  label: 'my-label-2',
+  value: 'my-value-2',
+};
 
 const defaultProps = {
   targetElement: mockElement,
-  items: [item],
+  items: [item1, item2],
 };
 
 describe('tooltip.vue', () => {
@@ -42,10 +48,14 @@ describe('tooltip.vue', () => {
       el
         .find('[data-j-tooltip__item__symbol]')
         .classes()
-        .includes(`lume-background-color--${item.color}`)
+        .includes(`lume-background-color--${item1.color}`)
     ).toBeTruthy();
-    expect(el.find('[data-j-tooltip__item__label]').text()).toEqual(item.label);
-    expect(el.find('[data-j-tooltip__item__value]').text()).toEqual(item.value);
+    expect(el.find('[data-j-tooltip__item__label]').text()).toEqual(
+      item1.label
+    );
+    expect(el.find('[data-j-tooltip__item__value]').text()).toEqual(
+      item1.value
+    );
   });
 
   describe('summary item', () => {
@@ -53,7 +63,7 @@ describe('tooltip.vue', () => {
       const wrapper = mount(LumeTooltip, {
         props: {
           ...defaultProps,
-          items: [{ ...item, isSummary: true }, item],
+          items: [{ ...item1, isSummary: true }, item1],
         },
       });
 
@@ -85,12 +95,22 @@ describe('tooltip.vue', () => {
       expect(el.exists()).toBeTruthy();
     });
 
+    test('mounts component with inverse tooltip items', () => {
+      const wrapper = mount(LumeTooltip, {
+        props: { ...defaultProps, inverse: true },
+      });
+
+      const items = wrapper.findAll('.lume-tooltip__item');
+
+      expect(items[0].text()).toBe(item2.label + item2.value);
+    });
+
     describe('should format title according to options', () => {
       it('should format title with format string', () => {
         const wrapper = mount(LumeTooltip, {
           props: {
             title: 1234,
-            items: [item],
+            items: [item1],
             targetElement: mockElement,
             options: { titleFormat: '~s' },
           },
@@ -104,7 +124,7 @@ describe('tooltip.vue', () => {
         const wrapper = mount(LumeTooltip, {
           props: {
             title,
-            items: [item],
+            items: [item1],
             targetElement: mockElement,
             options: { titleFormat: (title) => title + '!' },
           },

--- a/packages/lib/src/components/core/lume-tooltip/lume-tooltip.vue
+++ b/packages/lib/src/components/core/lume-tooltip/lume-tooltip.vue
@@ -37,7 +37,7 @@
         </li>
         <slot name="items">
           <lume-tooltip-item
-            v-for="item in items"
+            v-for="item in computedItems"
             :key="item.label"
             :color="item.color"
           >
@@ -107,6 +107,10 @@ const props = defineProps({
       TOOLTIP_POSITIONS.includes(value as (typeof TOOLTIP_POSITIONS)[number]),
   },
   fixedPositioning: {
+    type: Boolean,
+    default: false,
+  },
+  inverse: {
     type: Boolean,
     default: false,
   },
@@ -182,6 +186,13 @@ const summaryItem = computed(
 );
 
 const hasSummary = computed(() => slots.summary || summaryItem.value.label);
+
+const computedItems = computed(() => {
+  if (props.inverse || allOptions.value.inverse) {
+    return [...items.value].reverse();
+  }
+  return items.value;
+});
 
 // Methods
 function initPopper() {

--- a/packages/lib/src/composables/options.ts
+++ b/packages/lib/src/composables/options.ts
@@ -26,6 +26,7 @@ export interface AxisOptions extends Options {
 
 export interface TooltipOptions extends Options {
   fixedPositioning?: boolean;
+  inverse?: boolean;
   offset?: number;
   position?: (typeof TOOLTIP_POSITIONS)[number];
   showTitle?: boolean;
@@ -33,8 +34,8 @@ export interface TooltipOptions extends Options {
   targetElement?: Element | 'self';
   titleFormat?: Format;
   valueFormat?: Format;
-  withPointerEvents?: boolean;
   withAnimation?: boolean;
+  withPointerEvents?: boolean;
 }
 
 type LegendPosition = 'top' | 'bottom';


### PR DESCRIPTION
Closes #379

## 📝 Description

Added the `inverse` property and option to `<lume-tooltip>`. If true, the items rendered in the tooltip order is reversed.

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

## 📝 Additional Information

Updated `<lume-stacked-bar-chart>` default options to reflect `inverse: true`, as per the design guidelines.
Also included a new unit test for this case and updated README documentation.

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
