### PR TITLE
🩹 Fix the horizontal stacked bar chart default options

### DIFF
--- a/packages/lib/src/components/charts/lume-stacked-bar-chart/defaults.ts
+++ b/packages/lib/src/components/charts/lume-stacked-bar-chart/defaults.ts
@@ -14,6 +14,6 @@ export const options = {
     xAxisOptions: { gridLines: true },
     yAxisOptions: { gridLines: false },
     margins: DEFAULT_MARGINS.HORIZONTAL,
-    tooltipOptions: { position: 'right', inverse: true },
+    tooltipOptions: { position: 'right' },
   },
 };


### PR DESCRIPTION
## 📝 Description

Removed `inverse:  true` from the horizontal stacked bar chart default options.

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

## 📝 Additional Information



### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
