### PR TITLE
✨ Add lume-alluvial-node-header component

### DIFF
--- a/packages/lib/src/components/groups/lume-alluvial-group/components/lume-alluvial-node-header/README.md
+++ b/packages/lib/src/components/groups/lume-alluvial-group/components/lume-alluvial-node-header/README.md
@@ -1,0 +1,42 @@
+# Node header
+
+A simple, wrapper component for the alluvial node header.
+
+## Usage
+
+### Importing
+
+```ts
+import { LumeAlluvialNodeHeader } from '@adyen/lume';
+```
+
+### Basic use
+
+To overwrite the default node header, add your content to the respective `node-header-{INDEX}` slot of LumeAlluvialDiagram:
+
+```html
+<lume-alluvial-diagram>
+  <template #node-header-0>
+    <lume-alluvial-node-header>
+      <template #before>
+        <my-custom-icon />
+      </template>
+
+      Custom header
+
+      <template #after>
+        <my-custom-icon />
+      </template>
+    </lume-alluvial-node-header>
+  </template>
+</lume-alluvial-diagram>
+```
+
+## API
+
+### Props
+
+| Name | Type     | Default  | Description                            |
+| ---- | -------- | -------- | -------------------------------------- |
+| `x`  | `number` | Required | The horizontal position of the header. |
+| `y`  | `number` | Required | The vertical position of the header.   |

--- a/packages/lib/src/components/groups/lume-alluvial-group/components/lume-alluvial-node-header/index.ts
+++ b/packages/lib/src/components/groups/lume-alluvial-group/components/lume-alluvial-node-header/index.ts
@@ -1,0 +1,1 @@
+export { default } from './lume-alluvial-node-header.vue';

--- a/packages/lib/src/components/groups/lume-alluvial-group/components/lume-alluvial-node-header/lume-alluvial-node-header.vue
+++ b/packages/lib/src/components/groups/lume-alluvial-group/components/lume-alluvial-node-header/lume-alluvial-node-header.vue
@@ -1,0 +1,38 @@
+<template>
+  <g :transform="`translate(${x}, ${y})`">
+    <g :transform="beforeTransform">
+      <slot name="before" />
+    </g>
+    <text
+      ref="textRef"
+      class="lume-alluvial-group__node-header lume-typography--caption"
+    >
+      <slot />
+    </text>
+    <g :transform="afterTransform">
+      <slot name="after" />
+    </g>
+  </g>
+</template>
+
+<script lang="ts" setup>
+import { computed, ref } from 'vue';
+
+defineProps({
+  x: { type: Number, required: true },
+  y: { type: Number, required: true },
+});
+
+const textRef = ref<SVGGraphicsElement>(null);
+
+const beforeTransform = computed(
+  () => textRef.value && `translate(${-textRef.value.getBBox().width / 2}, 0)`
+);
+const afterTransform = computed(
+  () => textRef.value && `translate(${textRef.value.getBBox().width / 2}, 0)`
+);
+</script>
+
+<style lang="scss" scoped>
+@use '../../styles';
+</style>

--- a/packages/lib/src/components/groups/lume-alluvial-group/lume-alluvial-group.vue
+++ b/packages/lib/src/components/groups/lume-alluvial-group/lume-alluvial-group.vue
@@ -5,15 +5,21 @@
   >
     <!-- Level titles -->
     <g v-if="nodeHeaders">
-      <text
-        v-for="header in nodeHeaders"
-        :key="`header_${header.x}`"
-        :x="header.x"
-        :y="-computedNodeHeaderPadding"
-        class="lume-alluvial-group__node-header lume-typography--caption"
-      >
-        {{ header.label }}
-      </text>
+      <template v-for="(header, index) in nodeHeaders">
+        <slot
+          :name="`node-header-${index}`"
+          :x="header.x"
+          :y="-computedNodeHeaderPadding"
+        >
+          <lume-alluvial-node-header
+            :key="`header_${header.x}`"
+            :x="header.x"
+            :y="-computedNodeHeaderPadding"
+          >
+            {{ header.label }}
+          </lume-alluvial-node-header>
+        </slot>
+      </template>
     </g>
 
     <!-- Links -->
@@ -171,6 +177,7 @@ import { computed, inject, PropType, ref, toRefs, watch } from 'vue';
 
 import LumeAlluvialNodeLabel from './components/lume-alluvial-node-label';
 import LumeAlluvialNodeValue from './components/lume-alluvial-node-value';
+import LumeAlluvialNodeHeader from './components/lume-alluvial-node-header';
 
 import { useFormat } from '@/composables/format';
 import { withGroupProps } from '@/composables/group-props';

--- a/packages/lib/src/components/index.ts
+++ b/packages/lib/src/components/index.ts
@@ -32,6 +32,7 @@ export { default as LumePoint } from './core/lume-point/lume-point.vue';
 export { default as LumeAlluvialGroup } from './groups/lume-alluvial-group/lume-alluvial-group.vue';
 export { default as LumeAlluvialNodeLabel } from './groups/lume-alluvial-group/components/lume-alluvial-node-label/lume-alluvial-node-label.vue';
 export { default as LumeAlluvialNodeValue } from './groups/lume-alluvial-group/components/lume-alluvial-node-value/lume-alluvial-node-value.vue';
+export { default as LumeAlluvialNodeHeader } from './groups/lume-alluvial-group/components/lume-alluvial-node-header/lume-alluvial-node-header.vue';
 
 export { default as LumeBarGroup } from './groups/lume-bar-group/lume-bar-group.vue';
 export { default as LumeLineGroup } from './groups/lume-line-group/lume-line-group.vue';


### PR DESCRIPTION
Closes #387

## 📝 Description

Introduced a new component - `lume-alluvial-node-header`.
The alluvial group uses it and adds slots based on the `nodeHeaders` option.

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

## 📝 Additional Information

Added documentation for `lume-alluvial-node-header`.

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
