### PR TITLE
🚸 Improve lume-tooltip usability by introducing opened prop

### DIFF
--- a/packages/lib/src/components/charts/lume-alluvial-diagram/lume-alluvial-diagram.stories.ts
+++ b/packages/lib/src/components/charts/lume-alluvial-diagram/lume-alluvial-diagram.stories.ts
@@ -156,7 +156,7 @@ export const CustomNodeSlots: Story = {
         </lume-alluvial-node-value>
       </template>
       <template #tooltip="props">
-        <lume-tooltip v-bind="props" v-if="!!targetElement" :opened="!!targetElement" :target-element="targetElement">
+        <lume-tooltip v-bind="props" :opened="!!targetElement" :target-element="targetElement">
           Some additional info about the node.
         </lume-tooltip>
       </template>

--- a/packages/lib/src/components/charts/lume-bar-chart/lume-bar-chart.stories.ts
+++ b/packages/lib/src/components/charts/lume-bar-chart/lume-bar-chart.stories.ts
@@ -180,7 +180,7 @@ export const CustomTooltip: Story = {
     <div :style="{ width: args.width + 'px', height: args.orientation !== 'horizontal' ? args.height + 'px' : undefined }">
         <lume-bar-chart v-bind="args" :color="computedColor" ${actionEventHandlerTemplate}>
           <template #tooltip = "{ opened, data, hoveredIndex, targetElement }">
-            <lume-tooltip v-if="opened" :items="customItemsFunction(data, hoveredIndex)" :target-element="targetElement" position="top"/>
+            <lume-tooltip :opened="opened" :items="customItemsFunction(data, hoveredIndex)" :target-element="targetElement" position="top"/>
           </template>
         </lume-bar-chart>
     </div>

--- a/packages/lib/src/components/charts/lume-line-chart/lume-line-chart.stories.ts
+++ b/packages/lib/src/components/charts/lume-line-chart/lume-line-chart.stories.ts
@@ -133,7 +133,7 @@ export const MultipleDatasetsWithCustomTooltip: Story = {
     <lume-line-chart v-bind="args" ${actionEventHandlerTemplate}>
       <template #tooltip = "{ opened, data, hoveredIndex, targetElement, handleMouseEnter, handleMouseLeave }">
         <lume-tooltip
-          v-if="opened"
+          :opened="opened"
           :items="customItemsFunction(data, hoveredIndex)"
           :target-element="targetElement"
           :options="args.options.tooltipOptions"

--- a/packages/lib/src/components/core/lume-chart/README.md
+++ b/packages/lib/src/components/core/lume-chart/README.md
@@ -250,7 +250,7 @@ This is necessary so that the lume chart is aware when the user has moved inside
     #tooltip="{ opened, data, hoveredIndex, targetElement, handleMouseEnter, handleMouseLeave }"
   >
     <lume-tooltip
-      v-if="opened"
+      :opened="opened"
       ...
       :options="{ withPointerEvents: true }"
       @tooltip-mouseenter="handleMouseEnter"

--- a/packages/lib/src/components/core/lume-chart/lume-chart.spec.ts
+++ b/packages/lib/src/components/core/lume-chart/lume-chart.spec.ts
@@ -21,7 +21,8 @@ describe('lume-chart.vue', () => {
 
     const el = wrapper.find('[data-j-lume-chart]');
     expect(el.exists()).toBeTruthy();
-    expect(el.find('[data-j-lume-chart__tooltip]').exists()).toBe(false);
+    expect(el.find('[data-j-lume-chart__tooltip]').exists()).toBe(true);
+    expect(el.find('[data-j-lume-chart__tooltip]').isVisible()).toBe(false);
   });
 
   test('mounts component with tooltip disabled', () => {

--- a/packages/lib/src/components/core/lume-chart/lume-chart.vue
+++ b/packages/lib/src/components/core/lume-chart/lume-chart.vue
@@ -197,7 +197,7 @@
         :options="allOptions.tooltipOptions"
       >
         <lume-tooltip
-          v-if="isTooltipOpened"
+          v-if="allOptions.withTooltip !== false"
           v-bind="tooltipConfig"
           :position="tooltipPosition"
           :title="computedLabels[internalHoveredIndex]"
@@ -404,10 +404,6 @@ const { shouldGenerateTooltipAnchors } = useTooltipAnchors(
 const { tooltipConfig, showTooltip, hideTooltip } = useTooltip();
 
 const { getTooltipItems } = useTooltipItems(internalData);
-
-const isTooltipOpened = computed(
-  () => allOptions.value.withTooltip !== false && tooltipConfig.opened
-);
 
 const tooltipPosition = computed(
   () => allOptions.value.tooltipOptions?.position || 'top'

--- a/packages/lib/src/components/core/lume-tooltip/README.md
+++ b/packages/lib/src/components/core/lume-tooltip/README.md
@@ -18,10 +18,11 @@ import { LumeTooltip } from '@adyen/lume';
 
 ### Basic use
 
-To show a tooltip, provide a `targetElement` and an array of `items`.
+To show a tooltip, provide a `targetElement`, an `opened` boolean and an array of `items`.
 
 ```html
 <lume-tooltip
+  :opened="true"
   :targetElement="myElementRef"
   :items="myItems"
 />
@@ -38,8 +39,9 @@ Here's an example of overriding the default tooltip in a `lume-line-chart`:
   :data="myData"
   :labels="myLabels"
 >
-  <template #tooltip="{ data, hoveredIndex, targetElement }">
+  <template #tooltip="{ opened, data, hoveredIndex, targetElement }">
     <lume-tooltip
+      :opened="opened"
       :items="myCustomItemsFunction(data, hoveredIndex)"
       :target-element="targetElement"
     />
@@ -54,6 +56,7 @@ Here's an example of overriding the default tooltip in a `lume-line-chart`:
 | Name               | Type                 | Default  | Description                                                    |
 | ------------------ | -------------------- | -------- | -------------------------------------------------------------- |
 | `items`            | `Array<TooltipItem>` | Required | An array of items to display.                                  |
+| `opened`           | `boolean`            | `false`  | If the tooltip is visible or not.                              |
 | `targetElement`    | `Element`            | `null`   | A DOM element to attach to.                                    |
 | `position`         | `string`             | `"auto"` | Where the tooltip should be positioned relative to its target. |
 | `fixedPositioning` | `boolean`            | `false`  | If true, it will use fixed positioning instead of absolute.    |

--- a/packages/lib/src/components/core/lume-tooltip/lume-tooltip.vue
+++ b/packages/lib/src/components/core/lume-tooltip/lume-tooltip.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-show="targetElement"
+    v-show="opened && targetElement"
     ref="root"
     class="lume-tooltip lume-typography--caption"
     :class="{
@@ -92,6 +92,10 @@ import { TooltipOptions, useOptions, withOptions } from '@/composables/options';
 import { TOOLTIP_POSITIONS } from '@/utils/constants';
 
 const props = defineProps({
+  opened: {
+    type: Boolean,
+    default: false,
+  },
   targetElement: {
     type: Element,
     default: null,
@@ -210,14 +214,16 @@ function destroyPopper() {
   if (popper.value) {
     popper.value.destroy();
     emit('closed');
+    root.value.classList.remove('lume-tooltip--animated'); // Remove transition class
   }
 }
 
 function updatePopper() {
   if (!popper.value) return;
 
-  if (allOptions.value.withAnimation !== false)
+  if (allOptions.value.withAnimation !== false) {
     root.value.classList.add('lume-tooltip--animated'); // Add transition class
+  }
 
   props.targetElement
     ? (function () {

--- a/packages/lib/src/playground/custom-tooltip.stories.ts
+++ b/packages/lib/src/playground/custom-tooltip.stories.ts
@@ -69,7 +69,7 @@ export const CustomTooltipContent = ({ args }) => ({
         <lume-line-group v-bind="props" />
       </template>
       <template #tooltip-content="{ data, labels, hoveredIndex }">
-        On {{ labels[hoveredIndex] }}, the value was <strong>{{ data[0].values[hoveredIndex].value }}</strong>
+        On {{ labels[hoveredIndex] }}, the value was <strong>{{ data[0].values[hoveredIndex]?.value }}</strong>
       </template>
     </lume-chart>
   </div>
@@ -104,7 +104,7 @@ export const CustomTooltipContentWithSlots = ({ args }) => ({
         <lume-line-group v-bind="props" />
       </template>
       <template #tooltip="props">
-        <lume-tooltip v-if="props.opened" v-bind="props">
+        <lume-tooltip v-bind="props">
           <template #title>
             <lume-tooltip-title>Purchases of items in 2022</lume-tooltip-title>
           </template>


### PR DESCRIPTION
Closes #395 

## 📝 Description

- Added `opened` prop to `lume-tooltip` (defaults to `false`)
- Now adds/removes the animation class on Popper create/destroy (no more flying from the corner)

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

> **Note:** It still works the old way too (e.g. `<lume-tooltip v-if="opened" />`), but it's not recommended.

## 📝 Additional Information

Users can now do

```vue
<template #tooltip="tooltipProps">
  <lume-tooltip v-bind="tooltipProps">
    ...
  </lume-tooltip>
</template>
```

and it works out-of-the-box.

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
