### PR TITLE
✨ Add update event for hoveredIndex

### DIFF
--- a/packages/lib/src/components/charts/lume-alluvial-diagram/lume-alluvial-diagram.vue
+++ b/packages/lib/src/components/charts/lume-alluvial-diagram/lume-alluvial-diagram.vue
@@ -1,6 +1,6 @@
 <template>
   <lume-chart
-    v-bind="props"
+    v-bind="{ ...props, ...$attrs }"
     :options="getAlluvialDiagramOptions(allOptions)"
     data-j-alluvial-diagram
     v-on="componentEventPropagator"

--- a/packages/lib/src/components/charts/lume-grouped-bar-chart/lume-grouped-bar-chart.vue
+++ b/packages/lib/src/components/charts/lume-grouped-bar-chart/lume-grouped-bar-chart.vue
@@ -1,6 +1,6 @@
 <template>
   <lume-chart
-    v-bind="props"
+    v-bind="{ ...props, ...$attrs }"
     chart-type="grouped-bar"
     :options="allOptions"
     data-j-grouped-bar-chart

--- a/packages/lib/src/components/charts/lume-line-chart/lume-line-chart.vue
+++ b/packages/lib/src/components/charts/lume-line-chart/lume-line-chart.vue
@@ -1,6 +1,6 @@
 <template>
   <lume-chart
-    v-bind="props"
+    v-bind="{ ...props, ...$attrs }"
     chart-type="line"
     :options="allOptions"
     data-j-lume-line-chart

--- a/packages/lib/src/components/charts/lume-single-bar-chart/lume-single-bar-chart.vue
+++ b/packages/lib/src/components/charts/lume-single-bar-chart/lume-single-bar-chart.vue
@@ -1,6 +1,6 @@
 <template>
   <lume-chart
-    v-bind="props"
+    v-bind="{ ...props, ...$attrs }"
     chart-type="single-bar"
     :options="allOptions"
     data-j-single-bar-chart

--- a/packages/lib/src/components/charts/lume-stacked-bar-chart/lume-stacked-bar-chart.vue
+++ b/packages/lib/src/components/charts/lume-stacked-bar-chart/lume-stacked-bar-chart.vue
@@ -1,6 +1,6 @@
 <template>
   <lume-chart
-    v-bind="props"
+    v-bind="{ ...props, ...$attrs }"
     chart-type="stacked-bar"
     :options="allOptions"
     :x-scale="xScale"

--- a/packages/lib/src/components/core/lume-chart/lume-chart.vue
+++ b/packages/lib/src/components/core/lume-chart/lume-chart.vue
@@ -441,11 +441,13 @@ function handleInternalHover(index: number) {
     showTooltip(targetElement);
   }
   emit('hovered-index-changed', { newIndex: index, oldIndex });
+  emit('update:hoveredIndex', index);
 }
 
 function handleHideTooltip() {
   hideTooltip();
   internalHoveredIndex.value = -1;
+  emit('update:hoveredIndex', -1);
 }
 
 function handleExternalHover(index: number) {

--- a/packages/lib/src/composables/events.ts
+++ b/packages/lib/src/composables/events.ts
@@ -32,6 +32,7 @@ const CHART_EVENTS = [
   'tooltip-closed',
 
   'hovered-index-changed',
+  'update:hoveredIndex',
 ];
 
 // Used to propagate events from the top-most component (needed for Vue 2)

--- a/packages/lib/src/docs/storybook-helpers.ts
+++ b/packages/lib/src/docs/storybook-helpers.ts
@@ -36,6 +36,7 @@ const CHART_EVENTS = [
   'tooltip-mouseleave',
 
   'hovered-index-changed',
+  'update:hoveredIndex',
 ];
 
 export const COLOR_CLASS_MAP = {

--- a/packages/lib/src/playground/hovered-index-two-way-binding.stories.ts
+++ b/packages/lib/src/playground/hovered-index-two-way-binding.stories.ts
@@ -1,0 +1,44 @@
+import { ref, watch } from 'vue';
+import type { Meta, StoryObj } from '@storybook/vue3';
+
+import LumeLineChart from '../components/charts/lume-line-chart';
+
+import DATASETS from '@/docs/storybook-data/base-data';
+
+const meta: Meta<typeof LumeLineChart> = {
+  title: 'Playground/hovered-index two-way binding',
+  component: LumeLineChart,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof LumeLineChart>;
+
+export const Basic: Story = {
+  render: () => ({
+    components: { LumeLineChart },
+    setup() {
+      const index = ref(-1);
+      return { DATASETS, index };
+    },
+    template: `
+    <div>
+      <div style="width: 480px; height: 320px; margin-bottom: 16px">
+          <lume-line-chart v-if="__VUE_VERSION__ === 2" v-bind="DATASETS.AdoptedAnimals" v-bind:hoveredIndex.sync="index" />
+          <lume-line-chart v-else v-bind="DATASETS.AdoptedAnimals" v-model:hovered-index="index" />
+      </div>
+      <div>
+          <label for="slider">Hovered index: {{ index }}</label>
+          <input
+              style="width: 100%"
+              id="slider"
+              type="range"
+              min="-1"
+              :max="DATASETS.AdoptedAnimals.labels.length - 1"
+              v-model.number="index"
+          />
+      </div>
+    </div>
+    `,
+  }),
+};

--- a/packages/lib/src/playground/synced-tooltip.stories.ts
+++ b/packages/lib/src/playground/synced-tooltip.stories.ts
@@ -28,6 +28,7 @@ const meta: Meta<typeof LumeBarChart> = {
     ...withSizeArgs(),
     options: {
       margins: 'auto',
+      yAxisOptions: { tickCount: 5 },
     },
   },
 };
@@ -43,35 +44,33 @@ export const Basic: Story = {
       const containerStyle = {
         width: '480px',
         height: '320px',
-        padding: '8px',
-        border: '1px solid var(--lume-color--grey-50)',
-        borderRadius: '4px',
+        padding: '16px',
+        border: '1px solid var(--lume-color--grey-20)',
+        borderRadius: '8px',
         overflow: 'hidden',
       };
       const hoveredIndex = ref(-1);
       return { args, containerStyle, hoveredIndex };
     },
     template: `
-    <div :style="containerStyle" style="margin-bottom: 16px">
-        <lume-bar-chart
-            v-bind="args"
-            type="stacked"
-            :hovered-index="hoveredIndex"
-            @tooltip-opened="hoveredIndex = $event.index"
-            @tooltip-moved="hoveredIndex = $event.index"
-            @tooltip-closed="hoveredIndex = -1"
-        />
+    <div>
+      <div :style="containerStyle" style="margin-bottom: 16px">
+      <lume-bar-chart
+          v-bind="args"
+          type="stacked"
+          v-bind:hoveredIndex.sync="hoveredIndex"
+          v-model:hovered-index="hoveredIndex"
+      />
     </div>
     <div :style="containerStyle">
-        <lume-bar-chart
-            v-bind="args"
-            type="stacked"
-            :hovered-index="hoveredIndex"
-            @tooltip-opened="hoveredIndex = $event.index"
-            @tooltip-moved="hoveredIndex = $event.index"
-            @tooltip-closed="hoveredIndex = -1"
-        />
+      <lume-bar-chart
+          v-bind="args"
+          type="stacked"
+          v-bind:hoveredIndex.sync="hoveredIndex"
+          v-model:hovered-index="hoveredIndex"
+      />
     </div>
+  </div>
     `,
   }),
   args: {

--- a/packages/lib/src/types/events.ts
+++ b/packages/lib/src/types/events.ts
@@ -66,6 +66,7 @@ export interface ChartEvents {
   (e: 'resize', p: ContainerSize): void;
 
   (e: 'hovered-index-changed', p: HoverIndexChangedEventPayload): void;
+  (e: 'update:hoveredIndex', p: number): void;
 
   (e: 'data-changed', p: DataChangedEventPayload<Data>): void;
   (e: 'labels-changed', p: DataChangedEventPayload<Array<string>>): void;


### PR DESCRIPTION
Closes #394

## 📝 Description

Added an `update` event for `hoveredIndex` (`update:hoveredIndex`) so that users can two-way bind this property.

Vue 2 example:

```vue
<lume-line-chart v-bind:hoveredIndex.sync="customIndex" />

<script setup>
const customIndex = ref(-1);
</script>
```

Vue 3 example:

```vue
<lume-line-chart v-model:hoveredIndex="customIndex" />

<script setup>
const customIndex = ref(-1);
</script>
```

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

## 📝 Additional Information

- Updated charts to also inherit attributes (`$attrs`) - needed to properly listen to `update:*` event(s)
- Added a playground Story and updates the synced tooltips Story

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
