### PR TITLE
🐛 Add missing color values in constants

### DIFF
--- a/packages/lib/src/utils/constants.ts
+++ b/packages/lib/src/utils/constants.ts
@@ -72,10 +72,22 @@ export enum DivergentColors {
 }
 
 export enum OtherColors {
-  Grey = 'grey',
+  White = 'white',
+  Black = 'black',
   Green = 'green',
   Orange = 'orange',
   Red = 'red',
+  Grey = 'grey',
+  Grey10 = 'grey-10',
+  Grey20 = 'grey-20',
+  Grey30 = 'grey-30',
+  Grey40 = 'grey-40',
+  Grey50 = 'grey-50',
+  Grey60 = 'grey-60',
+  Grey70 = 'grey-70',
+  Grey80 = 'grey-80',
+  Grey90 = 'grey-90',
+  Grey100 = 'grey-100',
 }
 
 export enum LegacyColors {


### PR DESCRIPTION
## 📝 Description

Constants were missing the sequential neutral (grey) colors, and black/white.

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

## 📝 Additional Information

--

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
