### PR TITLE
🩹 Emitting resize event from lume chart

### DIFF
--- a/packages/lib/src/components/core/lume-chart/lume-chart.vue
+++ b/packages/lib/src/components/core/lume-chart/lume-chart.vue
@@ -7,7 +7,7 @@
     :no-min-size="allOptions.noMinSize"
     :transparent-background="allOptions.transparentBackground"
     data-j-lume-chart
-    @resize="updateSize"
+    @resize="handleResize"
     @click="emit('chart-click', $event)"
     @mouseenter="emit('chart-mouseenter', $event)"
     @mouseleave="handleMouseleave"
@@ -277,6 +277,7 @@ import {
 import { warn, Warnings } from '@/utils/warnings';
 import { ChartType, Data } from '@/types/dataset';
 import { ChartEmits } from '@/types/events';
+import { ContainerSize } from '@/types/size';
 
 const props = defineProps({
   ...withChartProps(),
@@ -470,6 +471,11 @@ function handleMouseleave() {
     }
     emit('chart-mouseleave');
   }, 0);
+}
+
+function handleResize(size: ContainerSize) {
+  updateSize(size);
+  emit('resize', size);
 }
 
 function handleAxisMouseenter({ index, value, event }) {


### PR DESCRIPTION
## 📝 Description

Currently consumers cannot act upon resize for any of the lume charts. Emitting resize event from lume chart so that all the charts will have that emit.

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
