### PR TITLE
🐛 Fix lume-tooltip use v-if instead of v-show

### DIFF
--- a/packages/lib/src/components/core/lume-chart/lume-chart.spec.ts
+++ b/packages/lib/src/components/core/lume-chart/lume-chart.spec.ts
@@ -21,8 +21,7 @@ describe('lume-chart.vue', () => {
 
     const el = wrapper.find('[data-j-lume-chart]');
     expect(el.exists()).toBeTruthy();
-    expect(el.find('[data-j-lume-chart__tooltip]').exists()).toBe(true);
-    expect(el.find('[data-j-lume-chart__tooltip]').isVisible()).toBe(false);
+    expect(el.find('[data-j-lume-chart__tooltip]').exists()).toBe(false);
   });
 
   test('mounts component with tooltip disabled', () => {

--- a/packages/lib/src/components/core/lume-tooltip/lume-tooltip.spec.ts
+++ b/packages/lib/src/components/core/lume-tooltip/lume-tooltip.spec.ts
@@ -18,6 +18,7 @@ const item2 = {
 };
 
 const defaultProps = {
+  opened: true,
   targetElement: mockElement,
   items: [item1, item2],
 };
@@ -111,6 +112,7 @@ describe('tooltip.vue', () => {
           props: {
             title: 1234,
             items: [item1],
+            opened: true,
             targetElement: mockElement,
             options: { titleFormat: '~s' },
           },
@@ -125,6 +127,7 @@ describe('tooltip.vue', () => {
           props: {
             title,
             items: [item1],
+            opened: true,
             targetElement: mockElement,
             options: { titleFormat: (title) => title + '!' },
           },

--- a/packages/lib/src/components/core/lume-tooltip/lume-tooltip.vue
+++ b/packages/lib/src/components/core/lume-tooltip/lume-tooltip.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-show="opened && targetElement"
+    v-if="opened && targetElement"
     ref="root"
     class="lume-tooltip lume-typography--caption"
     :class="{
@@ -66,6 +66,7 @@ interface TooltipItem {
 <script setup lang="ts">
 import {
   computed,
+  nextTick,
   onBeforeUnmount,
   onMounted,
   PropType,
@@ -214,14 +215,15 @@ function destroyPopper() {
   if (popper.value) {
     popper.value.destroy();
     emit('closed');
-    root.value.classList.remove('lume-tooltip--animated'); // Remove transition class
+
+    root.value && root.value.classList.remove('lume-tooltip--animated'); // Remove transition class
   }
 }
 
 function updatePopper() {
   if (!popper.value) return;
 
-  if (allOptions.value.withAnimation !== false) {
+  if (allOptions.value.withAnimation !== false && root.value) {
     root.value.classList.add('lume-tooltip--animated'); // Add transition class
   }
 
@@ -237,9 +239,11 @@ function updatePopper() {
 // Watchers
 watch(
   () => props.targetElement,
-  (newValue, oldValue) => {
-    if (!oldValue && newValue) initPopper();
-    else updatePopper();
+  async (newValue, oldValue) => {
+    if (!oldValue && newValue) {
+      await nextTick(); // wait for `root` to be picked up
+      initPopper();
+    } else updatePopper();
   }
 );
 


### PR DESCRIPTION
## 📝 Description

Using `v-show` on tooltip would force consumers (especially custom tooltip implementations) to handle `hoveredIndex = -1` cases (when tooltip is *not* shown).  
This way there's no need to handle those cases because the tooltip will only render if `hoveredIndex > -1`

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

## 📝 Additional Information

--

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
