### PR TITLE
Exporting utils types to make it accessible for consumers

### DIFF
--- a/packages/lib/src/components/charts/lume-bar-chart/lume-bar-chart.spec.ts
+++ b/packages/lib/src/components/charts/lume-bar-chart/lume-bar-chart.spec.ts
@@ -9,7 +9,8 @@ import {
   yScale,
 } from '@test/unit/mock-data';
 import { flushPromises } from '@test/unit/flush-promises';
-import { CHART_TYPES, ChartType } from '@/utils/constants';
+import { CHART_TYPES } from '@/utils/constants';
+import type { ChartType } from '@/types/utils';
 
 const numberOfSets = 2;
 const numberOfBars = singleSetData[0].values.length;

--- a/packages/lib/src/components/charts/lume-bar-chart/lume-bar-chart.spec.ts
+++ b/packages/lib/src/components/charts/lume-bar-chart/lume-bar-chart.spec.ts
@@ -9,13 +9,13 @@ import {
   yScale,
 } from '@test/unit/mock-data';
 import { flushPromises } from '@test/unit/flush-promises';
-import { CHART_TYPES } from '@/utils/constants';
+
 import type { ChartType } from '@/types/utils';
 
 const numberOfSets = 2;
 const numberOfBars = singleSetData[0].values.length;
 const multiSetData = generateData(numberOfSets, singleSetData[0].values.length);
-const chartType: ChartType = CHART_TYPES.BAR;
+const chartType: ChartType = 'bar';
 
 const barChartTestSuiteFactory = (props) => new BaseTestSuite(BarChart, props);
 

--- a/packages/lib/src/components/charts/lume-bar-chart/lume-bar-chart.spec.ts
+++ b/packages/lib/src/components/charts/lume-bar-chart/lume-bar-chart.spec.ts
@@ -10,12 +10,12 @@ import {
 } from '@test/unit/mock-data';
 import { flushPromises } from '@test/unit/flush-promises';
 
-import type { ChartType } from '@/types/utils';
+import type { ChartTypeWithoutVariant } from '@/types/utils';
 
 const numberOfSets = 2;
 const numberOfBars = singleSetData[0].values.length;
 const multiSetData = generateData(numberOfSets, singleSetData[0].values.length);
-const chartType: ChartType = 'bar';
+const chartType: ChartTypeWithoutVariant = 'bar';
 
 const barChartTestSuiteFactory = (props) => new BaseTestSuite(BarChart, props);
 

--- a/packages/lib/src/components/charts/lume-bar-chart/lume-bar-chart.stories.ts
+++ b/packages/lib/src/components/charts/lume-bar-chart/lume-bar-chart.stories.ts
@@ -12,7 +12,9 @@ import DATASETS from '@/docs/storybook-data/base-data';
 import LumeBarChart from './index';
 import LumeTooltip from '../../core/lume-tooltip/index';
 
-import { Colors, ORIENTATIONS } from '@/utils/constants';
+import { ORIENTATIONS } from '@/utils/constants';
+
+import { Colors } from '@/types/utils';
 
 const meta: Meta<typeof LumeBarChart> = {
   title: 'Charts/Bar chart',

--- a/packages/lib/src/components/charts/lume-grouped-bar-chart/lume-grouped-bar-chart.spec.ts
+++ b/packages/lib/src/components/charts/lume-grouped-bar-chart/lume-grouped-bar-chart.spec.ts
@@ -10,11 +10,10 @@ import {
   yScale,
 } from '@test/unit/mock-data';
 
-import { CHART_TYPES } from '@/utils/constants';
 import type { ChartType, Orientation } from '@/types/utils';
 
 const orientation: Orientation = 'horizontal';
-const chartType: ChartType = CHART_TYPES.BAR;
+const chartType: ChartType = 'bar';
 const numberOfBars = data[0].values.length;
 
 const groupedBarChartTestSuiteFactory = (props) =>

--- a/packages/lib/src/components/charts/lume-grouped-bar-chart/lume-grouped-bar-chart.spec.ts
+++ b/packages/lib/src/components/charts/lume-grouped-bar-chart/lume-grouped-bar-chart.spec.ts
@@ -10,10 +10,10 @@ import {
   yScale,
 } from '@test/unit/mock-data';
 
-import type { ChartType, Orientation } from '@/types/utils';
+import type { ChartTypeWithoutVariant, Orientation } from '@/types/utils';
 
 const orientation: Orientation = 'horizontal';
-const chartType: ChartType = 'bar';
+const chartType: ChartTypeWithoutVariant = 'bar';
 const numberOfBars = data[0].values.length;
 
 const groupedBarChartTestSuiteFactory = (props) =>

--- a/packages/lib/src/components/charts/lume-grouped-bar-chart/lume-grouped-bar-chart.spec.ts
+++ b/packages/lib/src/components/charts/lume-grouped-bar-chart/lume-grouped-bar-chart.spec.ts
@@ -10,7 +10,8 @@ import {
   yScale,
 } from '@test/unit/mock-data';
 
-import { CHART_TYPES, ChartType, Orientation } from '@/utils/constants';
+import { CHART_TYPES } from '@/utils/constants';
+import type { ChartType, Orientation } from '@/types/utils';
 
 const orientation: Orientation = 'horizontal';
 const chartType: ChartType = CHART_TYPES.BAR;

--- a/packages/lib/src/components/charts/lume-line-chart/lume-line-chart.spec.ts
+++ b/packages/lib/src/components/charts/lume-line-chart/lume-line-chart.spec.ts
@@ -9,11 +9,11 @@ import {
   xScale,
   yScale,
 } from '@test/unit/mock-data';
-import { CHART_TYPES } from '@/utils/constants';
+
 import type { ChartType } from '@/types/utils';
 
 const numberOfLines = data[0].values.length;
-const chartType: ChartType = CHART_TYPES.LINE;
+const chartType: ChartType = 'line';
 const lineChartTestSuiteFactory = (props) =>
   new BaseTestSuite(LumeLineChart, props);
 

--- a/packages/lib/src/components/charts/lume-line-chart/lume-line-chart.spec.ts
+++ b/packages/lib/src/components/charts/lume-line-chart/lume-line-chart.spec.ts
@@ -9,7 +9,8 @@ import {
   xScale,
   yScale,
 } from '@test/unit/mock-data';
-import { CHART_TYPES, ChartType } from '@/utils/constants';
+import { CHART_TYPES } from '@/utils/constants';
+import type { ChartType } from '@/types/utils';
 
 const numberOfLines = data[0].values.length;
 const chartType: ChartType = CHART_TYPES.LINE;

--- a/packages/lib/src/components/charts/lume-line-chart/lume-line-chart.spec.ts
+++ b/packages/lib/src/components/charts/lume-line-chart/lume-line-chart.spec.ts
@@ -10,10 +10,10 @@ import {
   yScale,
 } from '@test/unit/mock-data';
 
-import type { ChartType } from '@/types/utils';
+import type { ChartTypeWithoutVariant } from '@/types/utils';
 
 const numberOfLines = data[0].values.length;
-const chartType: ChartType = 'line';
+const chartType: ChartTypeWithoutVariant = 'line';
 const lineChartTestSuiteFactory = (props) =>
   new BaseTestSuite(LumeLineChart, props);
 

--- a/packages/lib/src/components/charts/lume-line-chart/lume-line-chart.stories.ts
+++ b/packages/lib/src/components/charts/lume-line-chart/lume-line-chart.stories.ts
@@ -12,7 +12,7 @@ import DATASETS from '@/docs/storybook-data/base-data';
 import LumeLineChart from './lume-line-chart.vue';
 import LumeTooltip from '../../core/lume-tooltip/index';
 import LumeTooltipSummary from '../../core/lume-tooltip/components/lume-tooltip-summary/index';
-import { Colors } from '@/utils/constants';
+import { Colors } from '@/types/utils';
 
 const meta: Meta<typeof LumeLineChart> = {
   title: 'Charts/Line chart',

--- a/packages/lib/src/components/charts/lume-single-bar-chart/lume-single-bar-chart.spec.ts
+++ b/packages/lib/src/components/charts/lume-single-bar-chart/lume-single-bar-chart.spec.ts
@@ -2,7 +2,8 @@ import SingleBarChart from './lume-single-bar-chart.vue';
 
 import { BaseTestSuite } from '@test/unit/reusable.test';
 import { data, labels, xScale, yScale } from '@test/unit/mock-data';
-import { CHART_TYPES, ChartType } from '@/utils/constants';
+import { CHART_TYPES } from '@/utils/constants';
+import type { ChartType } from '@/types/utils';
 
 const numberOfPositiveBars = 5;
 const numberOfNegativeBars = 2;

--- a/packages/lib/src/components/charts/lume-single-bar-chart/lume-single-bar-chart.spec.ts
+++ b/packages/lib/src/components/charts/lume-single-bar-chart/lume-single-bar-chart.spec.ts
@@ -2,13 +2,13 @@ import SingleBarChart from './lume-single-bar-chart.vue';
 
 import { BaseTestSuite } from '@test/unit/reusable.test';
 import { data, labels, xScale, yScale } from '@test/unit/mock-data';
-import { CHART_TYPES } from '@/utils/constants';
+
 import type { ChartType } from '@/types/utils';
 
 const numberOfPositiveBars = 5;
 const numberOfNegativeBars = 2;
 const totalNumberOfBars = data[0].values.length;
-const chartType: ChartType = CHART_TYPES.BAR;
+const chartType: ChartType = 'bar';
 
 const singleBarChartTestSuiteFactory = (props) =>
   new BaseTestSuite(SingleBarChart, props);

--- a/packages/lib/src/components/charts/lume-single-bar-chart/lume-single-bar-chart.spec.ts
+++ b/packages/lib/src/components/charts/lume-single-bar-chart/lume-single-bar-chart.spec.ts
@@ -3,12 +3,12 @@ import SingleBarChart from './lume-single-bar-chart.vue';
 import { BaseTestSuite } from '@test/unit/reusable.test';
 import { data, labels, xScale, yScale } from '@test/unit/mock-data';
 
-import type { ChartType } from '@/types/utils';
+import type { ChartTypeWithoutVariant } from '@/types/utils';
 
 const numberOfPositiveBars = 5;
 const numberOfNegativeBars = 2;
 const totalNumberOfBars = data[0].values.length;
-const chartType: ChartType = 'bar';
+const chartType: ChartTypeWithoutVariant = 'bar';
 
 const singleBarChartTestSuiteFactory = (props) =>
   new BaseTestSuite(SingleBarChart, props);

--- a/packages/lib/src/components/charts/lume-stacked-bar-chart/lume-stacked-bar-chart.spec.ts
+++ b/packages/lib/src/components/charts/lume-stacked-bar-chart/lume-stacked-bar-chart.spec.ts
@@ -9,11 +9,10 @@ import {
   xScale,
 } from '@test/unit/mock-data';
 
-import { CHART_TYPES } from '@/utils/constants';
 import type { ChartType, Orientation } from '@/types/utils';
 
 const orientation: Orientation = 'horizontal';
-const chartType: ChartType = CHART_TYPES.BAR;
+const chartType: ChartType = 'bar';
 const numberOfBars = data[0].values.length;
 
 const stackedBarChartTestSuiteFactory = (props) =>

--- a/packages/lib/src/components/charts/lume-stacked-bar-chart/lume-stacked-bar-chart.spec.ts
+++ b/packages/lib/src/components/charts/lume-stacked-bar-chart/lume-stacked-bar-chart.spec.ts
@@ -9,10 +9,10 @@ import {
   xScale,
 } from '@test/unit/mock-data';
 
-import type { ChartType, Orientation } from '@/types/utils';
+import type { ChartTypeWithoutVariant, Orientation } from '@/types/utils';
 
 const orientation: Orientation = 'horizontal';
-const chartType: ChartType = 'bar';
+const chartType: ChartTypeWithoutVariant = 'bar';
 const numberOfBars = data[0].values.length;
 
 const stackedBarChartTestSuiteFactory = (props) =>

--- a/packages/lib/src/components/charts/lume-stacked-bar-chart/lume-stacked-bar-chart.spec.ts
+++ b/packages/lib/src/components/charts/lume-stacked-bar-chart/lume-stacked-bar-chart.spec.ts
@@ -9,7 +9,8 @@ import {
   xScale,
 } from '@test/unit/mock-data';
 
-import { CHART_TYPES, ChartType, Orientation } from '@/utils/constants';
+import { CHART_TYPES } from '@/utils/constants';
+import type { ChartType, Orientation } from '@/types/utils';
 
 const orientation: Orientation = 'horizontal';
 const chartType: ChartType = CHART_TYPES.BAR;

--- a/packages/lib/src/components/core/lume-axis/lume-axis.vue
+++ b/packages/lib/src/components/core/lume-axis/lume-axis.vue
@@ -93,15 +93,12 @@ import { useOptions, withOptions } from '@/composables/options';
 import { ComputedScaleBand, Scale } from '@/composables/scales';
 import { useSkip } from './composables/lume-skip';
 
-import {
-  AXIS_GHOST_PADDING,
-  Orientation,
-  ORIENTATIONS,
-} from '@/utils/constants';
+import { AXIS_GHOST_PADDING, ORIENTATIONS } from '@/utils/constants';
 import { isBandScale, isScaleEmpty } from '@/utils/helpers';
 import { svgCheck } from '@/utils/svg-check';
 import type { ContainerSize } from '@/types/size';
 import type { AxisOptions } from '@/types/options';
+import type { Orientation } from '@/types/utils';
 import type { AxisMixin, AxisMixinFunction, TickAttributes } from './types';
 
 import { xOptions, yOptions } from './defaults';
@@ -339,3 +336,4 @@ watch(props.containerSize, updateGridlines);
 
 onMounted(() => svgCheck(root.value));
 </script>
+@/types/types

--- a/packages/lib/src/components/core/lume-axis/lume-axis.vue
+++ b/packages/lib/src/components/core/lume-axis/lume-axis.vue
@@ -336,4 +336,3 @@ watch(props.containerSize, updateGridlines);
 
 onMounted(() => svgCheck(root.value));
 </script>
-@/types/types

--- a/packages/lib/src/components/core/lume-bar/lume-bar.stories.ts
+++ b/packages/lib/src/components/core/lume-bar/lume-bar.stories.ts
@@ -5,7 +5,7 @@ import { withSizeArgs, withSizeArgTypes } from '@/docs/storybook-helpers';
 
 import LumeBar from './lume-bar.vue';
 
-import { Colors } from '@/utils/constants';
+import { Colors } from '@/types/utils';
 
 const meta: Meta<typeof LumeBar> = {
   title: 'Core/Bar',

--- a/packages/lib/src/components/core/lume-chart-container/lume-chart-container.vue
+++ b/packages/lib/src/components/core/lume-chart-container/lume-chart-container.vue
@@ -103,4 +103,3 @@ watchEffect(() => {
 <style lang="scss" scoped>
 @use './styles';
 </style>
-@/types/types

--- a/packages/lib/src/components/core/lume-chart-container/lume-chart-container.vue
+++ b/packages/lib/src/components/core/lume-chart-container/lume-chart-container.vue
@@ -40,7 +40,7 @@
 import { computed, PropType, ref, toRefs, watchEffect } from 'vue';
 
 import { useResizeObserver } from '@/composables/resize';
-import { InternalMargins } from '@/utils/constants';
+import type { InternalMargins } from '@/types/utils';
 import type { ContainerSize } from '@/types/size';
 
 const props = defineProps({
@@ -103,3 +103,4 @@ watchEffect(() => {
 <style lang="scss" scoped>
 @use './styles';
 </style>
+@/types/types

--- a/packages/lib/src/components/core/lume-chart/lume-chart.vue
+++ b/packages/lib/src/components/core/lume-chart/lume-chart.vue
@@ -275,10 +275,11 @@ import {
   calculateMarginTop,
 } from '@/utils/margins';
 import { warn, Warnings } from '@/utils/warnings';
-import type { BarLineChartType, Data } from '@/types/dataset';
+import type { Data } from '@/types/dataset';
 import type { ChartEmits } from '@/types/events';
 import type { ContainerSize } from '@/types/size';
 import type { ChartOptions } from '@/types/options';
+import type { BarLineChartType } from '@/types/utils';
 
 const props = defineProps({
   ...withChartProps(),

--- a/packages/lib/src/components/core/lume-chart/lume-chart.vue
+++ b/packages/lib/src/components/core/lume-chart/lume-chart.vue
@@ -275,7 +275,7 @@ import {
   calculateMarginTop,
 } from '@/utils/margins';
 import { warn, Warnings } from '@/utils/warnings';
-import type { ChartType, Data } from '@/types/dataset';
+import type { BarLineChartType, Data } from '@/types/dataset';
 import type { ChartEmits } from '@/types/events';
 import type { ContainerSize } from '@/types/size';
 import type { ChartOptions } from '@/types/options';
@@ -283,7 +283,7 @@ import type { ChartOptions } from '@/types/options';
 const props = defineProps({
   ...withChartProps(),
   chartType: {
-    type: String as PropType<ChartType>,
+    type: String as PropType<BarLineChartType>,
     default: null,
   },
 });

--- a/packages/lib/src/components/core/lume-line/lume-line.stories.ts
+++ b/packages/lib/src/components/core/lume-line/lume-line.stories.ts
@@ -1,7 +1,7 @@
 import { computed } from 'vue';
 import type { Meta, StoryObj } from '@storybook/vue3';
 
-import { Colors } from '@/utils/constants';
+import { Colors } from '@/types/utils';
 
 import LumeLine from './lume-line.vue';
 

--- a/packages/lib/src/components/core/lume-line/lume-line.vue
+++ b/packages/lib/src/components/core/lume-line/lume-line.vue
@@ -25,9 +25,9 @@ const DEFAULT_LINE_WIDTH = 2; // 2px
 <script setup lang="ts">
 import { onMounted, ref } from 'vue';
 
-import { Colors } from '@/utils/constants';
-
 import { svgCheck } from '@/utils/svg-check';
+
+import { Colors } from '@/types/utils';
 
 defineProps({
   pathDefinition: {
@@ -70,3 +70,4 @@ onMounted(() => svgCheck(root.value));
 <style lang="scss" scoped>
 @use './styles';
 </style>
+@/types/types

--- a/packages/lib/src/components/core/lume-line/lume-line.vue
+++ b/packages/lib/src/components/core/lume-line/lume-line.vue
@@ -70,4 +70,3 @@ onMounted(() => svgCheck(root.value));
 <style lang="scss" scoped>
 @use './styles';
 </style>
-@/types/types

--- a/packages/lib/src/components/core/lume-point/lume-point.stories.ts
+++ b/packages/lib/src/components/core/lume-point/lume-point.stories.ts
@@ -1,7 +1,7 @@
 import { computed } from 'vue';
 import type { Meta, StoryObj } from '@storybook/vue3';
 
-import { Colors } from '@/utils/constants';
+import { Colors } from '@/types/utils';
 
 import LumePoint from './lume-point.vue';
 

--- a/packages/lib/src/components/core/lume-point/lume-point.vue
+++ b/packages/lib/src/components/core/lume-point/lume-point.vue
@@ -19,7 +19,7 @@ const DEFAULT_RADIUS = 4; // 4px; If together with a `lume-line`, should double 
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue';
 
-import { Colors } from '@/utils/constants';
+import { Colors } from '@/types/utils';
 import { svgCheck } from '@/utils/svg-check';
 
 const props = defineProps({
@@ -51,3 +51,4 @@ onMounted(() => svgCheck(root.value));
 <style lang="scss" scoped>
 @use './styles';
 </style>
+@/types/types

--- a/packages/lib/src/components/core/lume-point/lume-point.vue
+++ b/packages/lib/src/components/core/lume-point/lume-point.vue
@@ -51,4 +51,3 @@ onMounted(() => svgCheck(root.value));
 <style lang="scss" scoped>
 @use './styles';
 </style>
-@/types/types

--- a/packages/lib/src/components/groups/lume-alluvial-group/composables/alluvial-graph.ts
+++ b/packages/lib/src/components/groups/lume-alluvial-group/composables/alluvial-graph.ts
@@ -2,7 +2,7 @@ import { computed, ComputedRef, ref, Ref, watch } from 'vue';
 import { SankeyLink as D3SankeyLink, sankey } from 'd3-sankey';
 
 import { DEFAULT_COLOR } from '@/utils/colors';
-import { OtherColors } from '@/utils/constants';
+import { OtherColors } from '@/types/utils';
 import { Errors, error as logError } from '@/utils/errors';
 import { getAlluvialNodeId } from '../helpers';
 

--- a/packages/lib/src/components/groups/lume-alluvial-group/lume-alluvial-group.vue
+++ b/packages/lib/src/components/groups/lume-alluvial-group/lume-alluvial-group.vue
@@ -462,4 +462,3 @@ watch(() => props.hoveredElementId, handleExternalHover);
 <style lang="scss" scoped>
 @use './styles';
 </style>
-@/types/types

--- a/packages/lib/src/components/groups/lume-alluvial-group/lume-alluvial-group.vue
+++ b/packages/lib/src/components/groups/lume-alluvial-group/lume-alluvial-group.vue
@@ -187,7 +187,6 @@ import { useAlluvialGraph } from './composables/alluvial-graph';
 import { useAlluvialHover } from './composables/alluvial-hover';
 
 import { DEFAULT_COLOR } from '@/utils/colors';
-import { Color } from '@/utils/constants';
 import { warn, Warnings } from '@/utils/warnings';
 import {
   GHOST_STROKE_WIDTH_OFFSET,
@@ -213,6 +212,7 @@ import type {
   AlluvialLinkEventPayload,
   AlluvialNodeEventPayload,
 } from '@/types/events';
+import type { Color } from '@/types/utils';
 
 const props = defineProps({
   ...withGroupProps<AlluvialDiagramOptions, AlluvialNode>(),
@@ -462,3 +462,4 @@ watch(() => props.hoveredElementId, handleExternalHover);
 <style lang="scss" scoped>
 @use './styles';
 </style>
+@/types/types

--- a/packages/lib/src/components/groups/lume-bar-group/composables/bar-mixin.ts
+++ b/packages/lib/src/components/groups/lume-bar-group/composables/bar-mixin.ts
@@ -3,15 +3,12 @@ import { ScaleLinear } from 'd3';
 
 import { Scale } from '@/composables/scales';
 
-import {
-  BAR_TYPES,
-  BarType,
-  Orientation,
-  ORIENTATIONS,
-} from '@/utils/constants';
+import { BAR_TYPES, ORIENTATIONS } from '@/utils/constants';
+
 import { error, Errors } from '@/utils/errors';
 import { fillArrayWithNullValues } from '@/utils/helpers';
 import type { DatasetValueObject, InternalData } from '@/types/dataset';
+import type { BarType, Orientation } from '@/types/utils';
 
 function typeValidator(type: string): boolean {
   return Object.values(BAR_TYPES).includes(type as BarType) || type == null;

--- a/packages/lib/src/components/groups/lume-bar-group/composables/grouped-mixin.ts
+++ b/packages/lib/src/components/groups/lume-bar-group/composables/grouped-mixin.ts
@@ -3,8 +3,10 @@ import { scaleBand, ScaleBand } from 'd3';
 
 import { Scale } from '@/composables/scales';
 
-import { Colors, Orientation, ORIENTATIONS } from '@/utils/constants';
+import { ORIENTATIONS } from '@/utils/constants';
+
 import type { Data, DatasetValueObject } from '@/types/dataset';
+import { Colors, type Orientation } from '@/types/utils';
 
 const NULL_BAR = {
   x: 0,

--- a/packages/lib/src/components/groups/lume-bar-group/composables/single-mixin.ts
+++ b/packages/lib/src/components/groups/lume-bar-group/composables/single-mixin.ts
@@ -3,9 +3,10 @@ import { ScaleBand } from 'd3';
 
 import { Scale } from '@/composables/scales';
 
-import { Orientation, ORIENTATIONS } from '@/utils/constants';
+import { ORIENTATIONS } from '@/utils/constants';
 import { DEFAULT_COLOR } from '@/utils/colors';
 import type { Data, DatasetValueObject } from '@/types/dataset';
+import type { Orientation } from '@/types/utils';
 
 const NULL_BAR = {
   x: 0,

--- a/packages/lib/src/components/groups/lume-bar-group/composables/stacked-mixin.ts
+++ b/packages/lib/src/components/groups/lume-bar-group/composables/stacked-mixin.ts
@@ -3,7 +3,8 @@ import { scaleBand, ScaleBand, scaleLinear } from 'd3';
 
 import { getPaddedScale, Scale } from '@/composables/scales';
 
-import { Colors, Orientation, ORIENTATIONS } from '@/utils/constants';
+import { ORIENTATIONS } from '@/utils/constants';
+import { Colors, type Orientation } from '@/types/utils';
 import type { Data, DatasetValueObject } from '@/types/dataset';
 import type { BarChartOptions } from '@/types/options';
 import type { ContainerSize } from '@/types/size';

--- a/packages/lib/src/components/groups/lume-bar-group/lume-bar-group.spec.ts
+++ b/packages/lib/src/components/groups/lume-bar-group/lume-bar-group.spec.ts
@@ -4,7 +4,7 @@ import LumeBarGroup from './lume-bar-group.vue';
 
 import { data, xScale, yScale } from '@test/unit/mock-data';
 
-import { Orientation } from '@/utils/constants';
+import type { Orientation } from '@/types/utils';
 
 const orientation: Orientation = 'horizontal';
 

--- a/packages/lib/src/components/groups/lume-overlay-group/lume-overlay-group.vue
+++ b/packages/lib/src/components/groups/lume-overlay-group/lume-overlay-group.vue
@@ -74,4 +74,3 @@ function getOverlayBarAttributes(index: number) {
     };
 }
 </script>
-@/types/types

--- a/packages/lib/src/components/groups/lume-overlay-group/lume-overlay-group.vue
+++ b/packages/lib/src/components/groups/lume-overlay-group/lume-overlay-group.vue
@@ -25,7 +25,8 @@ import {
   getScaleStep,
   isBandScale,
 } from '@/utils/helpers';
-import { Orientation, ORIENTATIONS } from '@/utils/constants';
+import { ORIENTATIONS } from '@/utils/constants';
+import type { Orientation } from '@/types/utils';
 import { ScaleBand } from 'd3';
 
 const props = defineProps({
@@ -73,3 +74,4 @@ function getOverlayBarAttributes(index: number) {
     };
 }
 </script>
+@/types/types

--- a/packages/lib/src/composables/base.spec.ts
+++ b/packages/lib/src/composables/base.spec.ts
@@ -5,7 +5,7 @@ import { useBase, withBase } from './base';
 
 import { data, labels } from '@test/unit/mock-data';
 
-import { Orientation } from '@/utils/constants';
+import type { Orientation } from '@/types/utils';
 
 const getMixin = (orientation: Orientation = 'horizontal') => {
   let mixin = null;

--- a/packages/lib/src/composables/base.ts
+++ b/packages/lib/src/composables/base.ts
@@ -1,12 +1,6 @@
 import { computed, ComputedRef, PropType, reactive, Ref } from 'vue';
 
-import {
-  BAR_HEIGHT,
-  Colors,
-  DivergentColors,
-  Orientation,
-  ORIENTATIONS,
-} from '@/utils/constants';
+import { BAR_HEIGHT, ORIENTATIONS } from '@/utils/constants';
 
 import { computeColor } from '@/utils/colors';
 import {
@@ -15,6 +9,7 @@ import {
   nanoid,
 } from '@/utils/helpers';
 
+import { Colors, type DivergentColors, type Orientation } from '@/types/utils';
 import type {
   ColorPalette,
   Data,

--- a/packages/lib/src/composables/group-props.ts
+++ b/packages/lib/src/composables/group-props.ts
@@ -3,10 +3,11 @@ import { PropType } from 'vue';
 import { orientationValidator } from '@/composables/props';
 import { Scale } from '@/composables/scales';
 
-import { Orientation, ORIENTATIONS } from '@/utils/constants';
+import { ORIENTATIONS } from '@/utils/constants';
 import type { DatasetValueObject, InternalData } from '@/types/dataset';
 import type { ContainerSize } from '@/types/size';
 import type { Options } from '@/types/options';
+import type { Orientation } from '@/types/utils';
 
 export const withGroupProps = <
   T extends Options = Options,

--- a/packages/lib/src/composables/negative-values.spec.ts
+++ b/packages/lib/src/composables/negative-values.spec.ts
@@ -6,8 +6,8 @@ import { checkNegativeValues, useNegativeValues } from './negative-values';
 
 import { containerSize, data, xScale, yScale } from '@test/unit/mock-data';
 
-import { Orientation } from '@/utils/constants';
 import { Scale } from '@/composables/scales';
+import type { Orientation } from '@/types/utils';
 import type { InternalData } from '@/types/dataset';
 
 export const yScaleWithNegativeValues: Scale = scaleLinear<number>()

--- a/packages/lib/src/composables/negative-values.ts
+++ b/packages/lib/src/composables/negative-values.ts
@@ -2,11 +2,12 @@ import { computed, Ref } from 'vue';
 
 import { flatValues } from '@/utils/helpers';
 
-import { Orientation, ORIENTATIONS } from '@/utils/constants';
+import { ORIENTATIONS } from '@/utils/constants';
 import { Scale } from './scales';
 
 import type { InternalData } from '@/types/dataset';
 import type { ContainerSize } from '@/types/size';
+import type { Orientation } from '@/types/utils';
 
 export function checkNegativeValues(data: Ref<InternalData>) {
   const hasNegativeValues = computed(() =>

--- a/packages/lib/src/composables/props.ts
+++ b/packages/lib/src/composables/props.ts
@@ -4,8 +4,9 @@ import { DataValidator, withBase } from './base';
 import { withOptions } from './options';
 import { withScales } from './scales';
 
-import { Orientation, ORIENTATIONS } from '@/utils/constants';
+import { ORIENTATIONS } from '@/utils/constants';
 import type { ChartOptions, Options } from '@/types/options';
+import type { Orientation } from '@/types/utils';
 
 export function orientationValidator(orientation: string): boolean {
   return Object.values(ORIENTATIONS).includes(orientation as Orientation);

--- a/packages/lib/src/composables/scales.spec.ts
+++ b/packages/lib/src/composables/scales.spec.ts
@@ -11,12 +11,9 @@ import {
 
 import { containerSize, data, labels } from '@test/unit/mock-data';
 
-import {
-  Orientation,
-  PADDING_HORIZONTAL,
-  PADDING_VERTICAL,
-} from '@/utils/constants';
+import { PADDING_HORIZONTAL, PADDING_VERTICAL } from '@/utils/constants';
 import type { ChartOptions } from '@/types/options';
+import type { Orientation } from '@/types/utils';
 
 const aboveZeroDataSet = [
   { values: [{ value: 10 }, { value: 20 }, { value: 30 }, { value: 40 }] },

--- a/packages/lib/src/composables/scales.ts
+++ b/packages/lib/src/composables/scales.ts
@@ -4,7 +4,6 @@ import { ScaleBand, scaleBand, ScaleLinear, scaleLinear } from 'd3';
 import { flatValues, isBandScale } from '@/utils/helpers';
 
 import {
-  Orientation,
   ORIENTATIONS,
   PADDING_HORIZONTAL,
   PADDING_VERTICAL,
@@ -12,6 +11,7 @@ import {
 import type { ContainerSize } from '@/types/size';
 import type { InternalData } from '@/types/dataset';
 import type { BarChartOptions, ChartOptions } from '@/types/options';
+import type { Orientation } from '@/types/utils';
 
 export interface ComputedScaleBand extends ScaleBand<string | number> {
   labels: Array<string | number>;

--- a/packages/lib/src/composables/tooltip.spec.ts
+++ b/packages/lib/src/composables/tooltip.spec.ts
@@ -5,7 +5,7 @@ import { useTooltip, useTooltipAnchors, useTooltipItems } from './tooltip';
 
 import { data, labels, xScale, yScale } from '@test/unit/mock-data';
 
-import { Orientation } from '@/utils/constants';
+import type { Orientation } from '@/types/utils';
 import type { InternalData } from '@/types/dataset';
 
 const orientation: Orientation = 'vertical';

--- a/packages/lib/src/composables/tooltip.ts
+++ b/packages/lib/src/composables/tooltip.ts
@@ -2,10 +2,11 @@ import { computed, reactive, Ref, watch } from 'vue';
 
 import { getXByIndex, Scale } from './scales';
 
-import { NO_DATA, Orientation, ORIENTATIONS } from '@/utils/constants';
+import { NO_DATA, ORIENTATIONS } from '@/utils/constants';
 import { fillArrayWithNullValues } from '@/utils/helpers';
 import type { InternalData } from '@/types/dataset';
 import type { ChartOptions } from '@/types/options';
+import type { Orientation } from '@/types/utils';
 
 export interface AnchorAttributes {
   cx: number;

--- a/packages/lib/src/types/alluvial.ts
+++ b/packages/lib/src/types/alluvial.ts
@@ -6,8 +6,7 @@ import {
   SankeyExtraProperties,
 } from 'd3-sankey';
 import type { Dataset, DatasetValueObject } from '@/types/dataset';
-
-import { Color } from '@/utils/constants';
+import type { Color } from '@/types/utils';
 
 interface AlluvialNodeTarget {
   node: string;

--- a/packages/lib/src/types/dataset.ts
+++ b/packages/lib/src/types/dataset.ts
@@ -1,6 +1,10 @@
-import { Color } from '@/utils/constants';
+import type { Color } from '@/types/utils';
 
-export type ChartType = 'grouped-bar' | 'line' | 'single-bar' | 'stacked-bar';
+export type BarLineChartType =
+  | 'grouped-bar'
+  | 'line'
+  | 'single-bar'
+  | 'stacked-bar';
 
 type DatasetValueType = number | string | Array<number>;
 
@@ -21,7 +25,7 @@ export interface Dataset<T> {
   label?: string;
   areaColor?: Color;
   legend?: string;
-  type?: ChartType;
+  type?: BarLineChartType;
   isDashed?: (index: number) => boolean; // for line datasets
 }
 

--- a/packages/lib/src/types/dataset.ts
+++ b/packages/lib/src/types/dataset.ts
@@ -1,10 +1,4 @@
-import type { Color } from '@/types/utils';
-
-export type BarLineChartType =
-  | 'grouped-bar'
-  | 'line'
-  | 'single-bar'
-  | 'stacked-bar';
+import type { BarLineChartType, Color } from '@/types/utils';
 
 type DatasetValueType = number | string | Array<number>;
 

--- a/packages/lib/src/types/index.ts
+++ b/packages/lib/src/types/index.ts
@@ -1,4 +1,5 @@
 export * from './alluvial';
+export * from './utils';
 export * from './dataset';
 export * from './events';
 export * from './options';

--- a/packages/lib/src/types/options.ts
+++ b/packages/lib/src/types/options.ts
@@ -8,7 +8,9 @@ import type { ColorPalette } from './dataset';
 import type { SankeyNode } from 'd3-sankey';
 
 import type { Format } from '../composables/format';
-import { Margins, TOOLTIP_POSITIONS } from '../utils/constants';
+import type { Margins } from './utils';
+
+import { TOOLTIP_POSITIONS } from '../utils/constants';
 
 export interface AxisOptions extends Options {
   gridLines?: boolean;

--- a/packages/lib/src/types/utils.ts
+++ b/packages/lib/src/types/utils.ts
@@ -124,4 +124,10 @@ export type Orientation = 'horizontal' | 'vertical';
 
 export type BarType = 'single' | 'grouped' | 'stacked';
 
-export type ChartType = 'bar' | 'line' | 'alluvial' | 'sparkline';
+export type BarChartVariant = `${BarType}-bar`;
+
+export type BarLineChartType = BarChartVariant | 'line';
+
+export type AllChartType = 'bar' | BarLineChartType | 'alluvial' | 'sparkline';
+
+export type ChartTypeWithoutVariant = Exclude<AllChartType, BarChartVariant>;

--- a/packages/lib/src/types/utils.ts
+++ b/packages/lib/src/types/utils.ts
@@ -1,0 +1,127 @@
+export enum Colors {
+  Skyblue = 'skyblue',
+  Royalblue = 'royalblue',
+  Violet = 'violet',
+  Darkteal = 'darkteal',
+  Gold = 'gold',
+}
+
+export enum SequentialColors {
+  Skyblue10 = 'skyblue-10',
+  Skyblue20 = 'skyblue-20',
+  Skyblue30 = 'skyblue-30',
+  Skyblue40 = 'skyblue-40',
+  Skyblue50 = 'skyblue-50',
+  Skyblue60 = 'skyblue-60',
+  Skyblue70 = 'skyblue-70',
+  Skyblue80 = 'skyblue-80',
+  Skyblue90 = 'skyblue-90',
+  Skyblue100 = 'skyblue-100',
+
+  Royalblue10 = 'royalblue-10',
+  Royalblue20 = 'royalblue-20',
+  Royalblue30 = 'royalblue-30',
+  Royalblue40 = 'royalblue-40',
+  Royalblue50 = 'royalblue-50',
+  Royalblue60 = 'royalblue-60',
+  Royalblue70 = 'royalblue-70',
+  Royalblue80 = 'royalblue-80',
+  Royalblue90 = 'royalblue-90',
+  Royalblue100 = 'royalblue-100',
+
+  Violet10 = 'violet-10',
+  Violet20 = 'violet-20',
+  Violet30 = 'violet-30',
+  Violet40 = 'violet-40',
+  Violet50 = 'violet-50',
+  Violet60 = 'violet-60',
+  Violet70 = 'violet-70',
+  Violet80 = 'violet-80',
+  Violet90 = 'violet-90',
+  Violet100 = 'violet-100',
+
+  Darkteal10 = 'darkteal-10',
+  Darkteal20 = 'darkteal-20',
+  Darkteal30 = 'darkteal-30',
+  Darkteal40 = 'darkteal-40',
+  Darkteal50 = 'darkteal-50',
+  Darkteal60 = 'darkteal-60',
+  Darkteal70 = 'darkteal-70',
+  Darkteal80 = 'darkteal-80',
+  Darkteal90 = 'darkteal-90',
+  Darkteal100 = 'darkteal-100',
+
+  Gold10 = 'gold-10',
+  Gold20 = 'gold-20',
+  Gold30 = 'gold-30',
+  Gold40 = 'gold-40',
+  Gold50 = 'gold-50',
+  Gold60 = 'gold-60',
+  Gold70 = 'gold-70',
+  Gold80 = 'gold-80',
+  Gold90 = 'gold-90',
+  Gold100 = 'gold-100',
+}
+
+export enum DivergentColors {
+  SkyTeal = 'skyblue-darkteal',
+  VioletRoyal = 'violet-royalblue',
+  VioletTeal = 'violet-darkteal',
+  GoldTeal = 'gold-darkteal',
+  GoldRoyal = 'gold-royalblue',
+}
+
+export enum OtherColors {
+  White = 'white',
+  Black = 'black',
+  Green = 'green',
+  Orange = 'orange',
+  Red = 'red',
+  Grey = 'grey',
+  Grey10 = 'grey-10',
+  Grey20 = 'grey-20',
+  Grey30 = 'grey-30',
+  Grey40 = 'grey-40',
+  Grey50 = 'grey-50',
+  Grey60 = 'grey-60',
+  Grey70 = 'grey-70',
+  Grey80 = 'grey-80',
+  Grey90 = 'grey-90',
+  Grey100 = 'grey-100',
+}
+
+export enum LegacyColors {
+  '01' = '01',
+  '02' = '02',
+  '03' = '03',
+  '04' = '04',
+  '05' = '05',
+  '06' = '06',
+  '07' = '07',
+  '08' = '08',
+  '09' = '09',
+}
+
+export type Color = Colors | DivergentColors | LegacyColors | OtherColors;
+
+export type Margins =
+  | 'auto'
+  | {
+      top?: number | 'auto';
+      right?: number | 'auto';
+      bottom?: number | 'auto';
+      left?: number | 'auto';
+    };
+
+export type InternalMargins = {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+};
+
+export type Orientation = 'horizontal' | 'vertical';
+
+export type BarType = 'single' | 'grouped' | 'stacked';
+
+export type ChartType = 'bar' | 'line' | 'alluvial' | 'sparkline';

--- a/packages/lib/src/utils/colors.ts
+++ b/packages/lib/src/utils/colors.ts
@@ -1,12 +1,12 @@
 import { ColorPalette } from '@/types/dataset';
 import {
-  Color,
+  type Color,
   Colors,
   DivergentColors,
   LegacyColors,
   OtherColors,
   SequentialColors,
-} from '@/utils/constants';
+} from '@/types/utils';
 import { shiftItems } from './helpers';
 import { warn, Warnings } from './warnings';
 

--- a/packages/lib/src/utils/constants.ts
+++ b/packages/lib/src/utils/constants.ts
@@ -1,141 +1,15 @@
-export enum Colors {
-  Skyblue = 'skyblue',
-  Royalblue = 'royalblue',
-  Violet = 'violet',
-  Darkteal = 'darkteal',
-  Gold = 'gold',
-}
-
-export enum SequentialColors {
-  Skyblue10 = 'skyblue-10',
-  Skyblue20 = 'skyblue-20',
-  Skyblue30 = 'skyblue-30',
-  Skyblue40 = 'skyblue-40',
-  Skyblue50 = 'skyblue-50',
-  Skyblue60 = 'skyblue-60',
-  Skyblue70 = 'skyblue-70',
-  Skyblue80 = 'skyblue-80',
-  Skyblue90 = 'skyblue-90',
-  Skyblue100 = 'skyblue-100',
-
-  Royalblue10 = 'royalblue-10',
-  Royalblue20 = 'royalblue-20',
-  Royalblue30 = 'royalblue-30',
-  Royalblue40 = 'royalblue-40',
-  Royalblue50 = 'royalblue-50',
-  Royalblue60 = 'royalblue-60',
-  Royalblue70 = 'royalblue-70',
-  Royalblue80 = 'royalblue-80',
-  Royalblue90 = 'royalblue-90',
-  Royalblue100 = 'royalblue-100',
-
-  Violet10 = 'violet-10',
-  Violet20 = 'violet-20',
-  Violet30 = 'violet-30',
-  Violet40 = 'violet-40',
-  Violet50 = 'violet-50',
-  Violet60 = 'violet-60',
-  Violet70 = 'violet-70',
-  Violet80 = 'violet-80',
-  Violet90 = 'violet-90',
-  Violet100 = 'violet-100',
-
-  Darkteal10 = 'darkteal-10',
-  Darkteal20 = 'darkteal-20',
-  Darkteal30 = 'darkteal-30',
-  Darkteal40 = 'darkteal-40',
-  Darkteal50 = 'darkteal-50',
-  Darkteal60 = 'darkteal-60',
-  Darkteal70 = 'darkteal-70',
-  Darkteal80 = 'darkteal-80',
-  Darkteal90 = 'darkteal-90',
-  Darkteal100 = 'darkteal-100',
-
-  Gold10 = 'gold-10',
-  Gold20 = 'gold-20',
-  Gold30 = 'gold-30',
-  Gold40 = 'gold-40',
-  Gold50 = 'gold-50',
-  Gold60 = 'gold-60',
-  Gold70 = 'gold-70',
-  Gold80 = 'gold-80',
-  Gold90 = 'gold-90',
-  Gold100 = 'gold-100',
-}
-
-export enum DivergentColors {
-  SkyTeal = 'skyblue-darkteal',
-  VioletRoyal = 'violet-royalblue',
-  VioletTeal = 'violet-darkteal',
-  GoldTeal = 'gold-darkteal',
-  GoldRoyal = 'gold-royalblue',
-}
-
-export enum OtherColors {
-  White = 'white',
-  Black = 'black',
-  Green = 'green',
-  Orange = 'orange',
-  Red = 'red',
-  Grey = 'grey',
-  Grey10 = 'grey-10',
-  Grey20 = 'grey-20',
-  Grey30 = 'grey-30',
-  Grey40 = 'grey-40',
-  Grey50 = 'grey-50',
-  Grey60 = 'grey-60',
-  Grey70 = 'grey-70',
-  Grey80 = 'grey-80',
-  Grey90 = 'grey-90',
-  Grey100 = 'grey-100',
-}
-
-export enum LegacyColors {
-  '01' = '01',
-  '02' = '02',
-  '03' = '03',
-  '04' = '04',
-  '05' = '05',
-  '06' = '06',
-  '07' = '07',
-  '08' = '08',
-  '09' = '09',
-}
-
-export type Color = Colors | DivergentColors | LegacyColors | OtherColors;
-
-export type Margins =
-  | 'auto'
-  | {
-      top: number | 'auto';
-      right: number | 'auto';
-      bottom: number | 'auto';
-      left: number | 'auto';
-    };
-
-export type InternalMargins = {
-  top: number;
-  right: number;
-  bottom: number;
-  left: number;
-};
-
-export type Orientation = 'horizontal' | 'vertical';
+import type { BarType, ChartType, Orientation } from '../types/utils';
 
 export const ORIENTATIONS: Record<string, Orientation> = {
   HORIZONTAL: 'horizontal',
   VERTICAL: 'vertical',
 };
 
-export type BarType = 'single' | 'grouped' | 'stacked';
-
 export const BAR_TYPES: Record<string, BarType> = {
   SINGLE: 'single',
   GROUPED: 'grouped',
   STACKED: 'stacked',
 };
-
-export type ChartType = 'bar' | 'line' | 'alluvial' | 'sparkline';
 
 export const CHART_TYPES: Record<string, ChartType> = {
   BAR: 'bar',

--- a/packages/lib/src/utils/constants.ts
+++ b/packages/lib/src/utils/constants.ts
@@ -1,4 +1,4 @@
-import type { BarType, ChartType, Orientation } from '../types/utils';
+import type { BarType, Orientation } from '../types/utils';
 
 export const ORIENTATIONS: Record<string, Orientation> = {
   HORIZONTAL: 'horizontal',
@@ -9,13 +9,6 @@ export const BAR_TYPES: Record<string, BarType> = {
   SINGLE: 'single',
   GROUPED: 'grouped',
   STACKED: 'stacked',
-};
-
-export const CHART_TYPES: Record<string, ChartType> = {
-  BAR: 'bar',
-  LINE: 'line',
-  ALLUVIAL: 'alluvial',
-  SPARKLINE: 'sparkline',
 };
 
 export const NO_DATA = 'No data';

--- a/packages/lib/src/utils/margins.ts
+++ b/packages/lib/src/utils/margins.ts
@@ -1,4 +1,4 @@
-import { InternalMargins, Margins } from './constants';
+import type { InternalMargins, Margins } from '../types/utils';
 
 const DEFAULT_MARGIN_TOP = 16;
 const DEFAULT_MARGIN_RIGHT = 8;

--- a/packages/lib/test/unit/mock-data.ts
+++ b/packages/lib/test/unit/mock-data.ts
@@ -2,7 +2,7 @@ import { Data, DatasetValueObject } from '@/types/dataset';
 import { Scale } from '@/composables/scales';
 import { scaleBand, scaleLinear } from 'd3';
 import { ContainerSize } from '@/types/size';
-import { LegacyColors } from '@/utils/constants';
+import { LegacyColors } from '@/types/utils';
 
 const width = 640;
 const height = 480;

--- a/packages/lib/test/unit/reusable.test.ts
+++ b/packages/lib/test/unit/reusable.test.ts
@@ -4,7 +4,6 @@ import { mount, Wrapper } from '@vue/test-utils';
 import { LumeChart } from '@/components/core';
 
 import { generateData } from './mock-data';
-import { CHART_TYPES } from '@/utils/constants';
 
 type ComponentInstance = VueConstructor;
 type props = Record<string, unknown>;
@@ -58,7 +57,7 @@ export class BaseTestSuite {
   }
 
   private getNumberOfRecords(chartType, numberOfLabels, numberOfRecords) {
-    if (chartType === CHART_TYPES.BAR) return numberOfLabels;
+    if (chartType === 'bar') return numberOfLabels;
     return numberOfRecords;
   }
 


### PR DESCRIPTION
Relates to #401 

## 📝 Description

Exported util types so that the consumers can make use of it if needed

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
