### PR TITLE
🐛 Convert bar transform-origin to rem

### DIFF
--- a/packages/lib/src/components/core/lume-bar/composables/bar-transition.ts
+++ b/packages/lib/src/components/core/lume-bar/composables/bar-transition.ts
@@ -11,8 +11,17 @@ export function useBarTransition(
   const computedHeight = ref(0);
 
   const transformOrigin = computed(() => {
+    const remFontSize = parseFloat(
+      getComputedStyle(document.documentElement).fontSize
+    );
+
+    // Convert to REM so that it behaves correctly in Safari browsers
+    // https://github.com/Adyen/lume/issues/430
+    const originX = (x.value + width.value / 2) / remFontSize;
+    const originY = (y.value + height.value / 2) / remFontSize;
+
     // Calculates the middle point of a bar so that it can be rotated 180 deg
-    return `${x.value + width.value / 2}px ${y.value + height.value / 2}px`;
+    return `${originX}rem ${originY}rem`;
   });
 
   onMounted(() => {


### PR DESCRIPTION
Fixes #430 

## 📝 Description

Converted the px value for each bar `transform-origin` to `rem`.

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

## 📝 Additional Information

Reference: https://github.com/carbon-design-system/icons-motion/issues/103

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
