### PR TITLE
🐛 Horizontal bar charts without minimum size not calculating height on initial render

### DIFF
--- a/packages/lib/src/components/core/lume-chart-container/README.md
+++ b/packages/lib/src/components/core/lume-chart-container/README.md
@@ -69,12 +69,13 @@ You can set up your chart with `lume-chart-container` like so:
 
 ### Props
 
-| Name                    | Type            | Default | Description                                                 |
-| ----------------------- | --------------- | ------- | ----------------------------------------------------------- |
-| `margins`               | `Margins`       | `{}`    | Space around the chart.                                     |
-| `containerSize`         | `ContainerSize` | `{}`    | The calculated container size.                              |
-| `transparentBackground` | `boolean`       | `false` | Controls if the chart should have a transparent background. |
-| `noMinSize`             | `boolean`       | `false` | Controls if the chart shouldn't have minimum width/height.  |
+| Name                    | Type                         | Default      | Description                                                 |
+| ----------------------- | ---------------------------- | ------------ | ----------------------------------------------------------- |
+| `margins`               | `Margins`                    | `{}`         | Space around the chart.                                     |
+| `containerSize`         | `ContainerSize`              | `{}`         | The calculated container size.                              |
+| `transparentBackground` | `boolean`                    | `false`      | Controls if the chart should have a transparent background. |
+| `noMinSize`             | `boolean`                    | `false`      | Controls if the chart shouldn't have minimum width/height.  |
+| `orientation`           | `'vertical' \| 'horizontal'` | `'vertical'` | The chart's orientation.                                    |
 
 ### Events
 

--- a/packages/lib/src/components/core/lume-chart-container/lume-chart-container.vue
+++ b/packages/lib/src/components/core/lume-chart-container/lume-chart-container.vue
@@ -39,8 +39,10 @@
 <script setup lang="ts">
 import { computed, PropType, ref, toRefs, watchEffect } from 'vue';
 
+import { orientationValidator } from '@/composables/props';
 import { useResizeObserver } from '@/composables/resize';
-import type { InternalMargins } from '@/types/utils';
+import { ORIENTATIONS } from '@/utils/constants';
+import type { InternalMargins, Orientation } from '@/types/utils';
 import type { ContainerSize } from '@/types/size';
 
 const props = defineProps({
@@ -59,6 +61,11 @@ const props = defineProps({
   noMinSize: {
     type: Boolean,
     default: false,
+  },
+  orientation: {
+    type: String as PropType<Orientation>,
+    default: ORIENTATIONS.VERTICAL,
+    validator: orientationValidator,
   },
 });
 
@@ -84,7 +91,9 @@ watchEffect(() => {
   const { width } = resizeState.dimensions;
   const { height } = root.value.getBoundingClientRect();
 
-  if (!width || !height) return;
+  if (!width || (props.orientation === ORIENTATIONS.VERTICAL && !height)) {
+    return;
+  }
 
   const contentWidth = width - margins.value.left - margins.value.right;
   const contentHeight = height - margins.value.top - margins.value.bottom;

--- a/packages/lib/src/components/core/lume-chart/lume-chart.vue
+++ b/packages/lib/src/components/core/lume-chart/lume-chart.vue
@@ -6,6 +6,7 @@
     :container-size="containerSize"
     :no-min-size="allOptions.noMinSize"
     :transparent-background="allOptions.transparentBackground"
+    :orientation="orientation"
     data-j-lume-chart
     @resize="handleResize"
     @click="emit('chart-click', $event)"


### PR DESCRIPTION
## 📝 Description

A bar chart with `orientation: 'horizontal'` and `noMinSize: true` was rendering with `0px` height instead of the correct height based on bar height and count.

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

## 📝 Additional Information

--

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
