### PR TITLE
🐛 Fix type declaration exports

### DIFF
--- a/packages/vue2/package.json
+++ b/packages/vue2/package.json
@@ -8,7 +8,10 @@
     "dist/"
   ],
   "exports": {
-    ".": "./dist/index.js",
+    ".": {
+      "types": "./dist/@types/index.d.ts",
+      "default": "./dist/index.js"
+    },
     "./plugin": "./dist/plugin.js",
     "./styles": "./dist/styles/main.css",
     "./font": "./dist/styles/font.css",

--- a/packages/vue3/package.json
+++ b/packages/vue3/package.json
@@ -8,7 +8,10 @@
     "dist/"
   ],
   "exports": {
-    ".": "./dist/index.js",
+    ".": {
+      "types": "./dist/@types/index.d.ts",
+      "default": "./dist/index.js"
+    },
     "./plugin": "./dist/plugin.js",
     "./styles": "./dist/styles/main.css",
     "./font": "./dist/styles/font.css",


### PR DESCRIPTION
## 📝 Description

Fixes problem when importing components from `@adyen/lume`:

<img width="769" alt="image" src="https://github.com/user-attachments/assets/4c1e5b5d-8b35-436c-87ca-2852f6347f69">


## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

## 📝 Additional Information

--

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
