### PR TITLE
🐛 Assume null data as empty

### DIFF
--- a/packages/lib/src/components/core/lume-chart/lume-chart.spec.ts
+++ b/packages/lib/src/components/core/lume-chart/lume-chart.spec.ts
@@ -24,6 +24,27 @@ describe('lume-chart.vue', () => {
     expect(el.find('[data-j-lume-chart__tooltip]').exists()).toBe(false);
   });
 
+  test('mounts component with empty (null) data', () => {
+    const wrapper = mount(LumeChart, {
+      slots: {
+        groups: 'Mock groups',
+      },
+      props: {
+        ...defaultProps,
+        data: [
+          {
+            values: [null, null, null, null, null, null, null],
+            label: 'mock data',
+          },
+        ],
+      },
+    });
+
+    const el = wrapper.find('[data-j-lume-chart]');
+    expect(el.exists()).toBeTruthy();
+    expect(el.find('[data-j-lume-chart__tooltip]').exists()).toBe(false);
+  });
+
   test('mounts component with tooltip disabled', () => {
     const wrapper = mount(LumeChart, {
       slots: {

--- a/packages/lib/src/components/core/lume-chart/lume-chart.vue
+++ b/packages/lib/src/components/core/lume-chart/lume-chart.vue
@@ -370,8 +370,10 @@ const showYAxisTitle = computed(() => {
   return allOptions.value.yAxisOptions?.withTitle !== false && yAxisTitle.value;
 });
 
-const isEmpty = computed(() =>
-  data.value.every((dataset) => !dataset.values.length)
+const isEmpty = computed(
+  () =>
+    data.value.every((dataset) => !dataset.values.length) ||
+    data.value.every((dataset) => dataset.values.every((v) => v === null))
 );
 
 const isReady = computed(() => {
@@ -379,7 +381,7 @@ const isReady = computed(() => {
 
   const { noBaseScales } = allOptions.value;
 
-  if (!noBaseScales && !isEmpty.value) {
+  if (!noBaseScales) {
     conditions.push(() => !!(computedXScale.value && computedYScale.value));
   }
 


### PR DESCRIPTION

## 📝 Description

Assumes datasets filled with `null` values as an empty chart.

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

## 📝 Additional Information

--

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
