### PR TITLE
:sparkles: Added intellisense support for component properties in VsCode

### DIFF
--- a/packages/lib/src/global-components.d.ts
+++ b/packages/lib/src/global-components.d.ts
@@ -1,0 +1,62 @@
+/**
+ * This file is used to add intellisense for components in VsCode.
+ * @see https://github.com/vuejs/language-tools/blob/d8ed4c08389771668b6bb13b77e0c0965cc0e3df/extensions/vscode/README.md?plain=1#L87
+ */
+
+import {
+    LumeAlluvialDiagram,
+    LumeBarChart,
+    LumeSingleBarChart,
+    LumeGroupedBarChart,
+    LumeStackedBarChart,
+    LumeLineChart,
+    LumeSparklineChart,
+    LumeAxis,
+    LumeChart,
+    LumeChartContainer,
+    LumeChartLegend,
+    LumeTooltip,
+    LumeTooltipItem,
+    LumeTooltipSummary,
+    LumeTooltipTitle,
+    LumeBar,
+    LumeLine,
+    LumePoint,
+    LumeAlluvialGroup,
+    LumeAlluvialNodeLabel,
+    LumeAlluvialNodeValue,
+    LumeAlluvialNodeHeader,
+    LumeBarGroup,
+    LumeLineGroup,
+    LumeOverlayGroup
+} from './index';
+
+declare module 'vue' {
+    export interface GlobalComponents {
+        LumeAlluvialDiagram: typeof LumeAlluvialDiagram;
+        LumeBarChart: typeof LumeBarChart;
+        LumeSingleBarChart: typeof LumeSingleBarChart;
+        LumeGroupedBarChart: typeof LumeGroupedBarChart;
+        LumeStackedBarChart: typeof LumeStackedBarChart;
+        LumeLineChart: typeof LumeLineChart;
+        LumeSparklineChart: typeof LumeSparklineChart;
+        LumeAxis: typeof LumeAxis;
+        LumeChart: typeof LumeChart;
+        LumeChartContainer: typeof LumeChartContainer;
+        LumeChartLegend: typeof LumeChartLegend;
+        LumeTooltip: typeof LumeTooltip;
+        LumeTooltipItem: typeof LumeTooltipItem;
+        LumeTooltipSummary: typeof LumeTooltipSummary;
+        LumeTooltipTitle: typeof LumeTooltipTitle;
+        LumeBar: typeof LumeBar;
+        LumeLine: typeof LumeLine;
+        LumePoint: typeof LumePoint;
+        LumeAlluvialGroup: typeof LumeAlluvialGroup;
+        LumeAlluvialNodeLabel: typeof LumeAlluvialNodeLabel;
+        LumeAlluvialNodeValue: typeof LumeAlluvialNodeValue;
+        LumeAlluvialNodeHeader: typeof LumeAlluvialNodeHeader;
+        LumeBarGroup: typeof LumeBarGroup;
+        LumeLineGroup: typeof LumeLineGroup;
+        LumeOverlayGroup: typeof LumeOverlayGroup;
+    }
+}

--- a/packages/vue2/package.json
+++ b/packages/vue2/package.json
@@ -20,10 +20,11 @@
   },
   "types": "./dist/@types/index.d.ts",
   "scripts": {
-    "build": "NODE_ENV=production pnpm run build:vite && pnpm run build:font && pnpm run build:types",
+    "build": "NODE_ENV=production pnpm run build:vite && pnpm run build:font && pnpm run build:types && pnpm run build:copy-components-defs",
     "build:vite": "vite build",
     "build:font": "webpack",
     "build:types": "vue-tsc -p ./tsconfig.d.json",
+    "build:copy-components-defs": "cp ../lib/src/global-components.d.ts dist/@types/components.d.ts",
     "pack": "pnpm pack --pack-destination ../../",
     "postbuild": "node ../../build/postbuild.js",
     "storybook": "sb dev -p 9002 -c .storybook"

--- a/packages/vue3/package.json
+++ b/packages/vue3/package.json
@@ -20,11 +20,12 @@
   },
   "types": "./dist/@types/index.d.ts",
   "scripts": {
-    "build": "NODE_ENV=production pnpm run build:vite && pnpm run build:font && pnpm run build:types",
+    "build": "NODE_ENV=production pnpm run build:vite && pnpm run build:font && pnpm run build:types && pnpm run build:copy-components-defs",
     "build:vite": "vite build",
     "build:font": "webpack",
     "build:storybook": "sb build -c .storybook",
     "build:types": "vue-tsc -p ./tsconfig.d.json",
+    "build:copy-components-defs": "cp ../lib/src/global-components.d.ts dist/@types/components.d.ts",
     "pack": "pnpm pack --pack-destination ../../",
     "postbuild": "node ../../build/postbuild.js",
     "storybook": "sb dev -p 9003 -c .storybook",


### PR DESCRIPTION
## 📝 Description

I noticed that Lume components do not have any property intellisense in VsCode (and additional not type checking either).
In Vue you can do this by extending the `GlobalComponents` type which VsCode uses to for Vue components to figure out it's props.

This will greatly improve the user experience for users I think as it will save time having to look at documentation to find properties and for TS users it will add extra type checking to make sure values being set are correct.

This solution needs to be tested though but I was unable to get docker to run or was not sure if there is some testing playground app?

## 💥 Is this a breaking change (Yes/No):

- [X] No
- [X] Yes (please describe the impact and migration path for existing Lume users)

I checked both as for JS users there will be no impact, but for typescript users as there was not property type checking at all a feature like this could break type checkers in their application....

## 📝 Additional Information

- (optional) Add additional information

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
