### PR TITLE
🐛 Fix axis alignment when scale domain is 0 to 0

### DIFF
--- a/packages/lib/src/components/core/lume-axis/lume-axis.vue
+++ b/packages/lib/src/components/core/lume-axis/lume-axis.vue
@@ -179,22 +179,18 @@ const { allOptions } = useOptions<AxisOptions>(
 
 const { showTick } = useSkip(scale, tickRefs, allOptions);
 
+const alignAxisBaseline = computed(
+  () => isEmpty.value || !scale.value || isScaleEmpty(scale.value)
+);
+
 const axisTransform = computed(() => {
   // if empty, aligns baseline to the bottom
-  if (
-    computedType.value === 'y' &&
-    isEmpty.value &&
-    (!scale.value || isScaleEmpty(scale.value))
-  ) {
+  if (computedType.value === 'y' && alignAxisBaseline.value) {
     return `translate(0, ${containerSize.value?.height / 2})`;
   }
 
   // if empty, aligns baseline to the left
-  if (
-    computedType.value === 'x' &&
-    isEmpty.value &&
-    (!scale.value || isScaleEmpty(scale.value))
-  ) {
+  if (computedType.value === 'x' && alignAxisBaseline.value) {
     return `translate(-${containerSize.value?.width / 2}, ${
       containerSize.value?.height
     })`;


### PR DESCRIPTION

## 📝 Description

Fixes axes alignment when scale `domain` is zeros. This happens, for instance, when all dataset values are `0`.

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

## 📝 Additional Information

--

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
