### PR TITLE
⏪️ Revert "Convert bar transform-origin to rem"

### DIFF
--- a/packages/lib/src/components/core/lume-bar/composables/bar-transition.ts
+++ b/packages/lib/src/components/core/lume-bar/composables/bar-transition.ts
@@ -11,17 +11,8 @@ export function useBarTransition(
   const computedHeight = ref(0);
 
   const transformOrigin = computed(() => {
-    const remFontSize = parseFloat(
-      getComputedStyle(document.documentElement).fontSize
-    );
-
-    // Convert to REM so that it behaves correctly in Safari browsers
-    // https://github.com/Adyen/lume/issues/430
-    const originX = (x.value + width.value / 2) / remFontSize;
-    const originY = (y.value + height.value / 2) / remFontSize;
-
     // Calculates the middle point of a bar so that it can be rotated 180 deg
-    return `${originX}rem ${originY}rem`;
+    return `${x.value + width.value / 2}px ${y.value + height.value / 2}px`;
   });
 
   onMounted(() => {


### PR DESCRIPTION
This reverts commit 810ffb3e365ec2b4918ae63c2944b7f830b75827.

## 📝 Description

Add a brief description

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

## 📝 Additional Information

As per Safari's bugfix, `transform-origin` should be reverted and set in `px`.
Relevant links:
- https://bugs.webkit.org/show_bug.cgi?id=133150
- https://github.com/WebKit/WebKit/commit/c78d507eeee2bb3be38e5f5129c3af9f497bbd71
- https://developer.apple.com/documentation/safari-release-notes/safari-18_2-release-notes#Resolved-Issues

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
