### PR TITLE
🐛 Fix linear yScale for an all-negative domain

### DIFF
--- a/packages/lib/src/composables/scales.ts
+++ b/packages/lib/src/composables/scales.ts
@@ -148,7 +148,8 @@ function generateLinearScale(
 
   const minAvailableValue = Math.min(...allValues);
   const minValue = startOnZero && minAvailableValue > 0 ? 0 : minAvailableValue;
-  const maxValue = Math.max(...allValues);
+  let maxValue = Math.max(...allValues);
+  if (startOnZero && maxValue < 0) maxValue = 0; // Prevent scale break when all values are negative
   const domain =
     orientation === ORIENTATIONS.HORIZONTAL
       ? [minValue, maxValue]


### PR DESCRIPTION


## 📝 Description

Accounted for all negative values when defining `startOnZero` `maxValue`.

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

## 📝 Additional Information

Before, the negative area and, e.g. bars were rendering outside of the chart container box.

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
