### PR TITLE
🐛 Fix line null value start to be lower end of domain

### DIFF
--- a/packages/lib/src/components/groups/lume-line-group/lume-line-group.vue
+++ b/packages/lib/src/components/groups/lume-line-group/lume-line-group.vue
@@ -115,7 +115,10 @@ const computedGroupData = computed(() => {
   }
 
   // Compute line null values and return it
-  const { computedLineData } = useLineNullValues(data);
+  const { computedLineData } = useLineNullValues(
+    data,
+    yScale as Ref<ScaleLinear<number, number>>
+  );
 
   if (options.value.withTooltip !== false && tooltipAnchorAttributes?.value) {
     updateTooltipAnchorAttributes(computedLineData.value); // Updates tooltip anchors for null values
@@ -170,9 +173,9 @@ function getPathDefinition(lineIndex: number, datasetIndex: number) {
     lineIndex === 0
       ? []
       : [
-          getValuesFromDataset(datasetIndex)[lineIndex - 1]?.value,
-          getValuesFromDataset(datasetIndex)[lineIndex]?.value,
-        ];
+        getValuesFromDataset(datasetIndex)[lineIndex - 1]?.value,
+        getValuesFromDataset(datasetIndex)[lineIndex]?.value,
+      ];
 
   return (
     getLinePathDefinition(

--- a/packages/lib/src/composables/line-null-values.ts
+++ b/packages/lib/src/composables/line-null-values.ts
@@ -1,8 +1,12 @@
 import { computed, Ref } from 'vue';
+import type { ScaleLinear } from 'd3';
 import { NO_DATA } from '@/utils/constants';
 import type { DatasetValueObject, InternalData } from '@/types/dataset';
 
-export function useLineNullValues(data: Ref<InternalData>) {
+export function useLineNullValues(
+  data: Ref<InternalData>,
+  yScale?: Ref<ScaleLinear<number, number>>
+) {
   /**
    * Returns an array of intervals where the data is null.
    * Each interval is an array containing the indexes of null values
@@ -88,10 +92,11 @@ export function useLineNullValues(data: Ref<InternalData>) {
               let start = dataset.values[startIndex]?.value;
               let end = dataset.values[endIndex]?.value;
 
-              // If first/last value is `null`, use the first/last non-null value
+              // If first/last value is `null`, use the y scale minimum
               if (start == null) {
-                start = 0; // Start along the x-axis
-                end = 0;
+                const domain = yScale?.value?.domain?.();
+                start = domain?.[1] ?? 0;
+                end = start;
               } else if (end == null) end = start;
 
               return {


### PR DESCRIPTION

## 📝 Description

Fixed the start of null line charts to be the lower end of the scale domain

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

## 📝 Additional Information

\--

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
