### PR TITLE
⬆️ Upgrade Sass tooling

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,17 +35,14 @@ jobs:
       contents: read
 
   run-unit-tests:
-    name: Test on Node ${{ matrix.node_version }}
+    name: Test on latest LTS Node
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [18, 20] # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node version from .nvmrc
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version-file: '.nvmrc'
 
       - name: Install dependencies
         uses: pnpm/action-setup@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. Dates are displayed in UTC.
 
+#### [1.12.4](https://github.com/Adyen/lume/compare/1.12.3...1.12.4)
+
+> 17 July 2026
+
+- ⬆️ Upgrade Sass tooling and remove deprecation warnings
+
 #### [1.12.3](https://github.com/Adyen/lume/compare/1.12.2...1.12.3)
 
 - 🔧 Update pnpm config [`c824fda`](https://github.com/Adyen/lume/commit/c824fda7c3a4340426baf8110be2367bc0151aac)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adyen/lume",
-  "version": "1.12.3",
+  "version": "1.12.4",
   "description": "Lume is a Vue data visualization component library, built with Typescript and D3.",
   "type": "module",
   "license": "MIT",
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@eslint/js": "9.31.0",
     "@release-it-plugins/workspaces": "5.0.3",
-    "@types/node": "18.19.47",
+    "@types/node": "24.13.2",
     "@typescript-eslint/eslint-plugin": "8.38.0",
     "@typescript-eslint/parser": "8.38.0",
     "auto-changelog": "2.4.0",
@@ -36,8 +36,8 @@
     "prettier": "2.8.8",
     "release-it": "19.2.3",
     "resize-observer-polyfill": "1.5.1",
-    "sass": "1.89.2",
-    "sass-loader": "13.3.3",
+    "sass": "1.101.0",
+    "sass-loader": "17.0.0",
     "typescript": "5.9.2",
     "vue-eslint-parser": "10.1.3",
     "webpack": "5.104.1",

--- a/packages/lib/src/styles/_utilities.scss
+++ b/packages/lib/src/styles/_utilities.scss
@@ -37,7 +37,7 @@
 .lume-background-color {
   @each $name, $map in $lume-categorical-colors {
     &--#{$name} {
-      background-color: nth($map, 1);
+      background-color: list.nth($map, 1);
     }
   }
 
@@ -92,7 +92,7 @@
 
   @each $name, $map in $lume-categorical-colors {
     &--#{$name} {
-      fill: nth($map, 1);
+      fill: list.nth($map, 1);
     }
   }
 

--- a/packages/vue2/package.json
+++ b/packages/vue2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adyen/lume",
-  "version": "1.12.3",
+  "version": "1.12.4",
   "description": "Lume is a Vue data visualization component library, built with Typescript and D3.",
   "type": "module",
   "module": "dist/index.js",

--- a/packages/vue3/package.json
+++ b/packages/vue3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adyen/lume-vue3",
-  "version": "1.12.3",
+  "version": "1.12.4",
   "description": "Lume is a Vue data visualization component library, built with Typescript and D3.",
   "type": "module",
   "module": "dist/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,10 +60,10 @@ importers:
         version: 9.31.0
       '@release-it-plugins/workspaces':
         specifier: 5.0.3
-        version: 5.0.3(release-it@19.2.3(@types/node@18.19.47))
+        version: 5.0.3(release-it@19.2.3(@types/node@24.13.2))
       '@types/node':
-        specifier: 18.19.47
-        version: 18.19.47
+        specifier: 24.13.2
+        version: 24.13.2
       '@typescript-eslint/eslint-plugin':
         specifier: 8.38.0
         version: 8.38.0(@typescript-eslint/parser@8.38.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
@@ -96,16 +96,16 @@ importers:
         version: 2.8.8
       release-it:
         specifier: 19.2.3
-        version: 19.2.3(@types/node@18.19.47)
+        version: 19.2.3(@types/node@24.13.2)
       resize-observer-polyfill:
         specifier: 1.5.1
         version: 1.5.1
       sass:
-        specifier: 1.89.2
-        version: 1.89.2
+        specifier: 1.101.0
+        version: 1.101.0
       sass-loader:
-        specifier: 13.3.3
-        version: 13.3.3(sass@1.89.2)(webpack@5.104.1)
+        specifier: 17.0.0
+        version: 17.0.0(sass@1.101.0)(webpack@5.104.1)
       typescript:
         specifier: 5.9.2
         version: 5.9.2
@@ -148,7 +148,7 @@ importers:
         version: 2.4.6
       vitest:
         specifier: 2.1.9
-        version: 2.1.9(@types/node@18.19.47)(jiti@2.6.1)(jsdom@26.1.0)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.3)
+        version: 2.1.9(@types/node@24.13.2)(jiti@2.6.1)(jsdom@26.1.0)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3)
       vue:
         specifier: 3.3.7
         version: 3.3.7(typescript@5.9.2)
@@ -203,22 +203,22 @@ importers:
         version: 7.6.21(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/vue':
         specifier: 7.6.21
-        version: 7.6.21(@babel/core@7.28.3)(css-loader@7.1.4(webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4(webpack@5.104.1))))(vue@2.7.15)
+        version: 7.6.21(@babel/core@7.28.3)(css-loader@7.1.4(webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4)))(vue@2.7.15)
       '@storybook/vue-vite':
         specifier: 7.6.21
-        version: 7.6.21(@babel/core@7.28.3)(css-loader@7.1.4(webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4(webpack@5.104.1))))(typescript@5.9.2)(vite@6.4.2(@types/node@18.19.47)(jiti@2.6.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.3))(vue@2.7.15)
+        version: 7.6.21(@babel/core@7.28.3)(css-loader@7.1.4(webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4)))(typescript@5.9.2)(vite@6.4.2(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3))(vue@2.7.15)
       '@vitejs/plugin-vue2':
         specifier: 2.3.1
-        version: 2.3.1(vite@6.4.2(@types/node@18.19.47)(jiti@2.6.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.3))(vue@2.7.15)
+        version: 2.3.1(vite@6.4.2(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3))(vue@2.7.15)
       storybook-utils:
         specifier: workspace:storybook-utils@*
         version: link:../storybook-utils
       vite:
         specifier: 6.4.2
-        version: 6.4.2(@types/node@18.19.47)(jiti@2.6.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.3)
+        version: 6.4.2(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3)
       vite-plugin-static-copy:
         specifier: 3.1.2
-        version: 3.1.2(vite@6.4.2(@types/node@18.19.47)(jiti@2.6.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.3))
+        version: 3.1.2(vite@6.4.2(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3))
       vue:
         specifier: 2.7.15
         version: 2.7.15
@@ -264,13 +264,13 @@ importers:
         version: 8.6.15(storybook@8.6.17(prettier@2.8.8))(vue@3.3.7(typescript@5.9.2))
       '@storybook/vue3-vite':
         specifier: 7.6.21
-        version: 7.6.21(typescript@5.9.2)(vite@6.4.2(@types/node@18.19.47)(jiti@2.6.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.3))(vue@3.3.7(typescript@5.9.2))
+        version: 7.6.21(typescript@5.9.2)(vite@6.4.2(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3))(vue@3.3.7(typescript@5.9.2))
       '@vitejs/plugin-vue':
         specifier: 4.6.2
-        version: 4.6.2(vite@6.4.2(@types/node@18.19.47)(jiti@2.6.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.3))(vue@3.3.7(typescript@5.9.2))
+        version: 4.6.2(vite@6.4.2(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3))(vue@3.3.7(typescript@5.9.2))
       '@vitest/coverage-istanbul':
         specifier: 0.34.6
-        version: 0.34.6(vitest@2.1.9(@types/node@18.19.47)(jiti@2.6.1)(jsdom@26.1.0)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.3))
+        version: 0.34.6(vitest@2.1.9(@types/node@24.13.2)(jiti@2.6.1)(jsdom@26.1.0)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3))
       '@vue/test-utils':
         specifier: 2.4.6
         version: 2.4.6
@@ -282,13 +282,13 @@ importers:
         version: link:../storybook-utils
       vite:
         specifier: 6.4.2
-        version: 6.4.2(@types/node@18.19.47)(jiti@2.6.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.3)
+        version: 6.4.2(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3)
       vite-plugin-static-copy:
         specifier: 3.1.2
-        version: 3.1.2(vite@6.4.2(@types/node@18.19.47)(jiti@2.6.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.3))
+        version: 3.1.2(vite@6.4.2(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3))
       vitest:
         specifier: 2.1.9
-        version: 2.1.9(@types/node@18.19.47)(jiti@2.6.1)(jsdom@26.1.0)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.3)
+        version: 2.1.9(@types/node@24.13.2)(jiti@2.6.1)(jsdom@26.1.0)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3)
       vue:
         specifier: 3.3.7
         version: 3.3.7(typescript@5.9.2)
@@ -2522,6 +2522,9 @@ packages:
   '@types/node@18.19.47':
     resolution: {integrity: sha512-1f7dB3BL/bpd9tnDJrrHb66Y+cVrhxSOTGorRNdHwYTUlTay3HuTDPKo9a/4vX9pMQkhYBcAbL4jQdNlhCFP9A==}
 
+  '@types/node@24.13.2':
+    resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==}
+
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
@@ -3175,10 +3178,6 @@ packages:
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
-
-  chokidar@4.0.3:
-    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
-    engines: {node: '>= 14.16.0'}
 
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
@@ -5370,10 +5369,6 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
-  readdirp@4.1.2:
-    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
-    engines: {node: '>= 14.18.0'}
-
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
@@ -5518,28 +5513,27 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  sass-loader@13.3.3:
-    resolution: {integrity: sha512-mt5YN2F1MOZr3d/wBRcZxeFgwgkH44wVc2zohO2YF6JiOMkiXe4BYRZpSu2sO1g71mo/j16txzUhsKZlqjVGzA==}
-    engines: {node: '>= 14.15.0'}
+  sass-loader@17.0.0:
+    resolution: {integrity: sha512-0Ybm8ohBQ9LcrycVrFQp/KQBNX5a3Wda9/smS0mE/xLffzEnwvV8nykOzrbiSWNzTE3IB/jiXx8O4QmDPG2+Gw==}
+    engines: {node: '>= 22.11.0'}
     peerDependencies:
-      fibers: '>= 3.1.0'
-      node-sass: ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
+      '@rspack/core': 0.x || ^1.0.0 || ^2.0.0-0
       sass: ^1.3.0
       sass-embedded: '*'
       webpack: ^5.0.0
     peerDependenciesMeta:
-      fibers:
-        optional: true
-      node-sass:
+      '@rspack/core':
         optional: true
       sass:
         optional: true
       sass-embedded:
         optional: true
+      webpack:
+        optional: true
 
-  sass@1.89.2:
-    resolution: {integrity: sha512-xCmtksBKd/jdJ9Bt9p7nPKiuqrlBMBuuGkQlkhZjjQk3Ty48lv93k5Dq6OPkKt4XwxDJ7tvlfrTa1MPA9bf+QA==}
-    engines: {node: '>=14.0.0'}
+  sass@1.101.0:
+    resolution: {integrity: sha512-OL3GoQyoUdDt843DpVmDO6y2k1sc5IhUDSpu8XucEI+35neq5QivZ1iuegnpraEVTJXlQGK1gl27zKcTLEPbQw==}
+    engines: {node: '>=20.19.0'}
     hasBin: true
 
   saxes@6.0.0:
@@ -5956,6 +5950,9 @@ packages:
 
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
   undici@6.24.0:
     resolution: {integrity: sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==}
@@ -7402,128 +7399,128 @@ snapshots:
 
   '@inquirer/ansi@1.0.2': {}
 
-  '@inquirer/checkbox@4.3.2(@types/node@18.19.47)':
+  '@inquirer/checkbox@4.3.2(@types/node@24.13.2)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@18.19.47)
+      '@inquirer/core': 10.3.2(@types/node@24.13.2)
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@18.19.47)
+      '@inquirer/type': 3.0.10(@types/node@24.13.2)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 18.19.47
+      '@types/node': 24.13.2
 
-  '@inquirer/confirm@5.1.21(@types/node@18.19.47)':
+  '@inquirer/confirm@5.1.21(@types/node@24.13.2)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@18.19.47)
-      '@inquirer/type': 3.0.10(@types/node@18.19.47)
+      '@inquirer/core': 10.3.2(@types/node@24.13.2)
+      '@inquirer/type': 3.0.10(@types/node@24.13.2)
     optionalDependencies:
-      '@types/node': 18.19.47
+      '@types/node': 24.13.2
 
-  '@inquirer/core@10.3.2(@types/node@18.19.47)':
+  '@inquirer/core@10.3.2(@types/node@24.13.2)':
     dependencies:
       '@inquirer/ansi': 1.0.2
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@18.19.47)
+      '@inquirer/type': 3.0.10(@types/node@24.13.2)
       cli-width: 4.1.0
       mute-stream: 2.0.0
       signal-exit: 4.1.0
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 18.19.47
+      '@types/node': 24.13.2
 
-  '@inquirer/editor@4.2.23(@types/node@18.19.47)':
+  '@inquirer/editor@4.2.23(@types/node@24.13.2)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@18.19.47)
-      '@inquirer/external-editor': 1.0.3(@types/node@18.19.47)
-      '@inquirer/type': 3.0.10(@types/node@18.19.47)
+      '@inquirer/core': 10.3.2(@types/node@24.13.2)
+      '@inquirer/external-editor': 1.0.3(@types/node@24.13.2)
+      '@inquirer/type': 3.0.10(@types/node@24.13.2)
     optionalDependencies:
-      '@types/node': 18.19.47
+      '@types/node': 24.13.2
 
-  '@inquirer/expand@4.0.23(@types/node@18.19.47)':
+  '@inquirer/expand@4.0.23(@types/node@24.13.2)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@18.19.47)
-      '@inquirer/type': 3.0.10(@types/node@18.19.47)
+      '@inquirer/core': 10.3.2(@types/node@24.13.2)
+      '@inquirer/type': 3.0.10(@types/node@24.13.2)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 18.19.47
+      '@types/node': 24.13.2
 
-  '@inquirer/external-editor@1.0.3(@types/node@18.19.47)':
+  '@inquirer/external-editor@1.0.3(@types/node@24.13.2)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 18.19.47
+      '@types/node': 24.13.2
 
   '@inquirer/figures@1.0.15': {}
 
-  '@inquirer/input@4.3.1(@types/node@18.19.47)':
+  '@inquirer/input@4.3.1(@types/node@24.13.2)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@18.19.47)
-      '@inquirer/type': 3.0.10(@types/node@18.19.47)
+      '@inquirer/core': 10.3.2(@types/node@24.13.2)
+      '@inquirer/type': 3.0.10(@types/node@24.13.2)
     optionalDependencies:
-      '@types/node': 18.19.47
+      '@types/node': 24.13.2
 
-  '@inquirer/number@3.0.23(@types/node@18.19.47)':
+  '@inquirer/number@3.0.23(@types/node@24.13.2)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@18.19.47)
-      '@inquirer/type': 3.0.10(@types/node@18.19.47)
+      '@inquirer/core': 10.3.2(@types/node@24.13.2)
+      '@inquirer/type': 3.0.10(@types/node@24.13.2)
     optionalDependencies:
-      '@types/node': 18.19.47
+      '@types/node': 24.13.2
 
-  '@inquirer/password@4.0.23(@types/node@18.19.47)':
-    dependencies:
-      '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@18.19.47)
-      '@inquirer/type': 3.0.10(@types/node@18.19.47)
-    optionalDependencies:
-      '@types/node': 18.19.47
-
-  '@inquirer/prompts@7.10.1(@types/node@18.19.47)':
-    dependencies:
-      '@inquirer/checkbox': 4.3.2(@types/node@18.19.47)
-      '@inquirer/confirm': 5.1.21(@types/node@18.19.47)
-      '@inquirer/editor': 4.2.23(@types/node@18.19.47)
-      '@inquirer/expand': 4.0.23(@types/node@18.19.47)
-      '@inquirer/input': 4.3.1(@types/node@18.19.47)
-      '@inquirer/number': 3.0.23(@types/node@18.19.47)
-      '@inquirer/password': 4.0.23(@types/node@18.19.47)
-      '@inquirer/rawlist': 4.1.11(@types/node@18.19.47)
-      '@inquirer/search': 3.2.2(@types/node@18.19.47)
-      '@inquirer/select': 4.4.2(@types/node@18.19.47)
-    optionalDependencies:
-      '@types/node': 18.19.47
-
-  '@inquirer/rawlist@4.1.11(@types/node@18.19.47)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@18.19.47)
-      '@inquirer/type': 3.0.10(@types/node@18.19.47)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 18.19.47
-
-  '@inquirer/search@3.2.2(@types/node@18.19.47)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@18.19.47)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@18.19.47)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 18.19.47
-
-  '@inquirer/select@4.4.2(@types/node@18.19.47)':
+  '@inquirer/password@4.0.23(@types/node@24.13.2)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@18.19.47)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@18.19.47)
+      '@inquirer/core': 10.3.2(@types/node@24.13.2)
+      '@inquirer/type': 3.0.10(@types/node@24.13.2)
+    optionalDependencies:
+      '@types/node': 24.13.2
+
+  '@inquirer/prompts@7.10.1(@types/node@24.13.2)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.2(@types/node@24.13.2)
+      '@inquirer/confirm': 5.1.21(@types/node@24.13.2)
+      '@inquirer/editor': 4.2.23(@types/node@24.13.2)
+      '@inquirer/expand': 4.0.23(@types/node@24.13.2)
+      '@inquirer/input': 4.3.1(@types/node@24.13.2)
+      '@inquirer/number': 3.0.23(@types/node@24.13.2)
+      '@inquirer/password': 4.0.23(@types/node@24.13.2)
+      '@inquirer/rawlist': 4.1.11(@types/node@24.13.2)
+      '@inquirer/search': 3.2.2(@types/node@24.13.2)
+      '@inquirer/select': 4.4.2(@types/node@24.13.2)
+    optionalDependencies:
+      '@types/node': 24.13.2
+
+  '@inquirer/rawlist@4.1.11(@types/node@24.13.2)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.13.2)
+      '@inquirer/type': 3.0.10(@types/node@24.13.2)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 18.19.47
+      '@types/node': 24.13.2
 
-  '@inquirer/type@3.0.10(@types/node@18.19.47)':
+  '@inquirer/search@3.2.2(@types/node@24.13.2)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.13.2)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.13.2)
+      yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 18.19.47
+      '@types/node': 24.13.2
+
+  '@inquirer/select@4.4.2(@types/node@24.13.2)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@24.13.2)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.13.2)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.13.2
+
+  '@inquirer/type@3.0.10(@types/node@24.13.2)':
+    optionalDependencies:
+      '@types/node': 24.13.2
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -7577,7 +7574,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 18.19.47
+      '@types/node': 24.13.2
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -8053,12 +8050,12 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.26.10
 
-  '@release-it-plugins/workspaces@5.0.3(release-it@19.2.3(@types/node@18.19.47))':
+  '@release-it-plugins/workspaces@5.0.3(release-it@19.2.3(@types/node@24.13.2))':
     dependencies:
       detect-indent: 6.1.0
       detect-newline: 3.1.0
       execa: 8.0.1
-      release-it: 19.2.3(@types/node@18.19.47)
+      release-it: 19.2.3(@types/node@24.13.2)
       semver: 7.7.2
       url-join: 4.0.1
       validate-peer-dependencies: 1.2.0
@@ -8303,7 +8300,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@storybook/builder-vite@7.6.21(typescript@5.9.2)(vite@6.4.2(@types/node@18.19.47)(jiti@2.6.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.3))':
+  '@storybook/builder-vite@7.6.21(typescript@5.9.2)(vite@6.4.2(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3))':
     dependencies:
       '@storybook/channels': 7.6.21
       '@storybook/client-logger': 7.6.21
@@ -8321,7 +8318,7 @@ snapshots:
       fs-extra: 11.3.1
       magic-string: 0.30.18
       rollup: 4.59.0
-      vite: 6.4.2(@types/node@18.19.47)(jiti@2.6.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3)
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -8683,14 +8680,14 @@ snapshots:
       '@types/express': 4.17.23
       file-system-cache: 2.3.0
 
-  '@storybook/vue-vite@7.6.21(@babel/core@7.28.3)(css-loader@7.1.4(webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4(webpack@5.104.1))))(typescript@5.9.2)(vite@6.4.2(@types/node@18.19.47)(jiti@2.6.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.3))(vue@2.7.15)':
+  '@storybook/vue-vite@7.6.21(@babel/core@7.28.3)(css-loader@7.1.4(webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4)))(typescript@5.9.2)(vite@6.4.2(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3))(vue@2.7.15)':
     dependencies:
-      '@storybook/builder-vite': 7.6.21(typescript@5.9.2)(vite@6.4.2(@types/node@18.19.47)(jiti@2.6.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.3))
+      '@storybook/builder-vite': 7.6.21(typescript@5.9.2)(vite@6.4.2(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3))
       '@storybook/core-common': 7.6.21
       '@storybook/core-server': 7.6.21
-      '@storybook/vue': 7.6.21(@babel/core@7.28.3)(css-loader@7.1.4(webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4(webpack@5.104.1))))(vue@2.7.15)
+      '@storybook/vue': 7.6.21(@babel/core@7.28.3)(css-loader@7.1.4(webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4)))(vue@2.7.15)
       magic-string: 0.30.18
-      vite: 6.4.2(@types/node@18.19.47)(jiti@2.6.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3)
       vue: 2.7.15
       vue-docgen-api: 4.79.2(vue@2.7.15)
     transitivePeerDependencies:
@@ -8705,14 +8702,14 @@ snapshots:
       - utf-8-validate
       - vite-plugin-glimmerx
 
-  '@storybook/vue3-vite@7.6.21(typescript@5.9.2)(vite@6.4.2(@types/node@18.19.47)(jiti@2.6.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.3))(vue@3.3.7(typescript@5.9.2))':
+  '@storybook/vue3-vite@7.6.21(typescript@5.9.2)(vite@6.4.2(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3))(vue@3.3.7(typescript@5.9.2))':
     dependencies:
-      '@storybook/builder-vite': 7.6.21(typescript@5.9.2)(vite@6.4.2(@types/node@18.19.47)(jiti@2.6.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.3))
+      '@storybook/builder-vite': 7.6.21(typescript@5.9.2)(vite@6.4.2(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3))
       '@storybook/core-server': 7.6.21
       '@storybook/vue3': 7.6.21(vue@3.3.7(typescript@5.9.2))
-      '@vitejs/plugin-vue': 4.6.2(vite@6.4.2(@types/node@18.19.47)(jiti@2.6.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.3))(vue@3.3.7(typescript@5.9.2))
+      '@vitejs/plugin-vue': 4.6.2(vite@6.4.2(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3))(vue@3.3.7(typescript@5.9.2))
       magic-string: 0.30.18
-      vite: 6.4.2(@types/node@18.19.47)(jiti@2.6.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3)
       vue-docgen-api: 4.79.2(vue@3.3.7(typescript@5.9.2))
     transitivePeerDependencies:
       - '@preact/preset-vite'
@@ -8736,7 +8733,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.3.7(typescript@5.9.2)
-      vue-component-type-helpers: 3.3.2
+      vue-component-type-helpers: 3.3.7
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -8753,9 +8750,9 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.3.7(typescript@5.9.2)
-      vue-component-type-helpers: 3.3.2
+      vue-component-type-helpers: 3.3.7
 
-  '@storybook/vue@7.6.21(@babel/core@7.28.3)(css-loader@7.1.4(webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4(webpack@5.104.1))))(vue@2.7.15)':
+  '@storybook/vue@7.6.21(@babel/core@7.28.3)(css-loader@7.1.4(webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4)))(vue@2.7.15)':
     dependencies:
       '@babel/core': 7.28.3
       '@storybook/client-logger': 7.6.21
@@ -8764,7 +8761,7 @@ snapshots:
       '@storybook/global': 5.0.0
       '@storybook/preview-api': 7.6.21
       '@storybook/types': 7.6.21
-      css-loader: 7.1.4(webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4(webpack@5.104.1)))
+      css-loader: 7.1.4(webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4))
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 2.7.15
@@ -8798,15 +8795,15 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 18.19.47
+      '@types/node': 24.13.2
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 18.19.47
+      '@types/node': 24.13.2
 
   '@types/cross-spawn@6.0.6':
     dependencies:
-      '@types/node': 18.19.47
+      '@types/node': 24.13.2
 
   '@types/d3-array@3.2.1': {}
 
@@ -8957,7 +8954,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.6':
     dependencies:
-      '@types/node': 18.19.47
+      '@types/node': 24.13.2
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.5
@@ -8975,7 +8972,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 18.19.47
+      '@types/node': 24.13.2
 
   '@types/http-errors@2.0.5': {}
 
@@ -9003,12 +9000,16 @@ snapshots:
 
   '@types/node-fetch@2.6.13':
     dependencies:
-      '@types/node': 18.19.47
+      '@types/node': 24.13.2
       form-data: 4.0.4
 
   '@types/node@18.19.47':
     dependencies:
       undici-types: 5.26.5
+
+  '@types/node@24.13.2':
+    dependencies:
+      undici-types: 7.18.2
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -9031,12 +9032,12 @@ snapshots:
   '@types/send@0.17.5':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 18.19.47
+      '@types/node': 24.13.2
 
   '@types/serve-static@1.15.8':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 18.19.47
+      '@types/node': 24.13.2
       '@types/send': 0.17.5
 
   '@types/unist@2.0.11': {}
@@ -9142,17 +9143,17 @@ snapshots:
       '@typescript-eslint/types': 8.38.0
       eslint-visitor-keys: 4.2.1
 
-  '@vitejs/plugin-vue2@2.3.1(vite@6.4.2(@types/node@18.19.47)(jiti@2.6.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.3))(vue@2.7.15)':
+  '@vitejs/plugin-vue2@2.3.1(vite@6.4.2(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3))(vue@2.7.15)':
     dependencies:
-      vite: 6.4.2(@types/node@18.19.47)(jiti@2.6.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3)
       vue: 2.7.15
 
-  '@vitejs/plugin-vue@4.6.2(vite@6.4.2(@types/node@18.19.47)(jiti@2.6.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.3))(vue@3.3.7(typescript@5.9.2))':
+  '@vitejs/plugin-vue@4.6.2(vite@6.4.2(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3))(vue@3.3.7(typescript@5.9.2))':
     dependencies:
-      vite: 6.4.2(@types/node@18.19.47)(jiti@2.6.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3)
       vue: 3.3.7(typescript@5.9.2)
 
-  '@vitest/coverage-istanbul@0.34.6(vitest@2.1.9(@types/node@18.19.47)(jiti@2.6.1)(jsdom@26.1.0)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.3))':
+  '@vitest/coverage-istanbul@0.34.6(vitest@2.1.9(@types/node@24.13.2)(jiti@2.6.1)(jsdom@26.1.0)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3))':
     dependencies:
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-instrument: 6.0.3
@@ -9161,7 +9162,7 @@ snapshots:
       istanbul-reports: 3.2.0
       picocolors: 1.1.1
       test-exclude: 6.0.0
-      vitest: 2.1.9(@types/node@18.19.47)(jiti@2.6.1)(jsdom@26.1.0)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.3)
+      vitest: 2.1.9(@types/node@24.13.2)(jiti@2.6.1)(jsdom@26.1.0)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -9172,13 +9173,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.9(vite@6.4.2(@types/node@18.19.47)(jiti@2.6.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.3))':
+  '@vitest/mocker@2.1.9(vite@6.4.2(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.18
     optionalDependencies:
-      vite: 6.4.2(@types/node@18.19.47)(jiti@2.6.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3)
 
   '@vitest/pretty-format@2.1.9':
     dependencies:
@@ -9818,10 +9819,6 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  chokidar@4.0.3:
-    dependencies:
-      readdirp: 4.1.2
-
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
@@ -9959,7 +9956,7 @@ snapshots:
 
   crypto-random-string@2.0.0: {}
 
-  css-loader@7.1.4(webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4(webpack@5.104.1))):
+  css-loader@7.1.4(webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.10)
       postcss: 8.5.10
@@ -9970,7 +9967,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.3
     optionalDependencies:
-      webpack: 5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4(webpack@5.104.1))
+      webpack: 5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4)
 
   css-loader@7.1.4(webpack@5.104.1):
     dependencies:
@@ -11003,17 +11000,17 @@ snapshots:
 
   ini@1.3.8: {}
 
-  inquirer@12.11.1(@types/node@18.19.47):
+  inquirer@12.11.1(@types/node@24.13.2):
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@18.19.47)
-      '@inquirer/prompts': 7.10.1(@types/node@18.19.47)
-      '@inquirer/type': 3.0.10(@types/node@18.19.47)
+      '@inquirer/core': 10.3.2(@types/node@24.13.2)
+      '@inquirer/prompts': 7.10.1(@types/node@24.13.2)
+      '@inquirer/type': 3.0.10(@types/node@24.13.2)
       mute-stream: 2.0.0
       run-async: 4.0.6
       rxjs: 7.8.2
     optionalDependencies:
-      '@types/node': 18.19.47
+      '@types/node': 24.13.2
 
   internmap@1.0.1: {}
 
@@ -11199,7 +11196,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 18.19.47
+      '@types/node': 24.13.2
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -11216,7 +11213,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.19.47
+      '@types/node': 24.13.2
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -11224,13 +11221,13 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 18.19.47
+      '@types/node': 24.13.2
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 18.19.47
+      '@types/node': 24.13.2
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -12154,8 +12151,6 @@ snapshots:
     dependencies:
       picomatch: 2.3.2
 
-  readdirp@4.1.2: {}
-
   readdirp@5.0.0: {}
 
   recast@0.23.11:
@@ -12193,7 +12188,7 @@ snapshots:
     dependencies:
       jsesc: 3.0.2
 
-  release-it@19.2.3(@types/node@18.19.47):
+  release-it@19.2.3(@types/node@24.13.2):
     dependencies:
       '@nodeutils/defaults-deep': 1.1.0
       '@octokit/rest': 22.0.1
@@ -12203,7 +12198,7 @@ snapshots:
       ci-info: 4.3.1
       eta: 4.5.0
       git-url-parse: 16.1.0
-      inquirer: 12.11.1(@types/node@18.19.47)
+      inquirer: 12.11.1(@types/node@24.13.2)
       issue-parser: 7.0.1
       lodash.merge: 4.6.2
       mime-types: 3.0.2
@@ -12347,16 +12342,14 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@13.3.3(sass@1.89.2)(webpack@5.104.1):
-    dependencies:
-      neo-async: 2.6.2
-      webpack: 5.104.1(webpack-cli@5.1.4)
+  sass-loader@17.0.0(sass@1.101.0)(webpack@5.104.1):
     optionalDependencies:
-      sass: 1.89.2
+      sass: 1.101.0
+      webpack: 5.104.1(webpack-cli@5.1.4)
 
-  sass@1.89.2:
+  sass@1.101.0:
     dependencies:
-      chokidar: 4.0.3
+      chokidar: 5.0.0
       immutable: 5.1.5
       source-map-js: 1.2.1
     optionalDependencies:
@@ -12644,14 +12637,14 @@ snapshots:
       type-fest: 0.16.0
       unique-string: 2.0.0
 
-  terser-webpack-plugin@5.3.16(esbuild@0.25.0)(webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4(webpack@5.104.1))):
+  terser-webpack-plugin@5.3.16(esbuild@0.25.0)(webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.30
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       serialize-javascript: 7.0.5
       terser: 5.43.1
-      webpack: 5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4(webpack@5.104.1))
+      webpack: 5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4)
     optionalDependencies:
       esbuild: 0.25.0
     optional: true
@@ -12775,6 +12768,8 @@ snapshots:
 
   undici-types@5.26.5: {}
 
+  undici-types@7.18.2: {}
+
   undici@6.24.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
@@ -12881,13 +12876,13 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-node@2.1.9(@types/node@18.19.47)(jiti@2.6.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.3):
+  vite-node@2.1.9(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 1.1.2
-      vite: 6.4.2(@types/node@18.19.47)(jiti@2.6.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -12902,16 +12897,16 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-static-copy@3.1.2(vite@6.4.2(@types/node@18.19.47)(jiti@2.6.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.3)):
+  vite-plugin-static-copy@3.1.2(vite@6.4.2(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3)):
     dependencies:
       chokidar: 3.6.0
       fs-extra: 11.3.1
       p-map: 7.0.3
       picocolors: 1.1.1
       tinyglobby: 0.2.14
-      vite: 6.4.2(@types/node@18.19.47)(jiti@2.6.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3)
 
-  vite@6.4.2(@types/node@18.19.47)(jiti@2.6.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.3):
+  vite@6.4.2(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3):
     dependencies:
       esbuild: 0.25.0
       fdir: 6.5.0(picomatch@2.3.2)
@@ -12920,17 +12915,17 @@ snapshots:
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 18.19.47
+      '@types/node': 24.13.2
       fsevents: 2.3.3
       jiti: 2.6.1
-      sass: 1.89.2
+      sass: 1.101.0
       terser: 5.43.1
       yaml: 2.8.3
 
-  vitest@2.1.9(@types/node@18.19.47)(jiti@2.6.1)(jsdom@26.1.0)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.3):
+  vitest@2.1.9(@types/node@24.13.2)(jiti@2.6.1)(jsdom@26.1.0)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@6.4.2(@types/node@18.19.47)(jiti@2.6.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.3))
+      '@vitest/mocker': 2.1.9(vite@6.4.2(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -12946,11 +12941,11 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.1.1
       tinyrainbow: 1.2.0
-      vite: 6.4.2(@types/node@18.19.47)(jiti@2.6.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.3)
-      vite-node: 2.1.9(@types/node@18.19.47)(jiti@2.6.1)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3)
+      vite-node: 2.1.9(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 18.19.47
+      '@types/node': 24.13.2
       jsdom: 26.1.0
     transitivePeerDependencies:
       - jiti
@@ -13115,7 +13110,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4(webpack@5.104.1)):
+  webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -13139,7 +13134,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.3.16(esbuild@0.25.0)(webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4(webpack@5.104.1)))
+      terser-webpack-plugin: 5.3.16(esbuild@0.25.0)(webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4))
       watchpack: 2.4.4
       webpack-sources: 3.3.3
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,7 @@ overrides:
   qs: 6.15.2
   rollup: 4.59.0
   send: 0.19.0
+  semver: 7.7.3
   serialize-javascript: 7.0.5
   serve-static: 1.16.0
   store2: 2.14.4
@@ -203,10 +204,10 @@ importers:
         version: 7.6.21(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/vue':
         specifier: 7.6.21
-        version: 7.6.21(@babel/core@7.28.3)(css-loader@7.1.4(webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4)))(vue@2.7.15)
+        version: 7.6.21(@babel/core@7.28.3)(css-loader@7.1.4(webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4(webpack@5.104.1))))(vue@2.7.15)
       '@storybook/vue-vite':
         specifier: 7.6.21
-        version: 7.6.21(@babel/core@7.28.3)(css-loader@7.1.4(webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4)))(typescript@5.9.2)(vite@6.4.2(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3))(vue@2.7.15)
+        version: 7.6.21(@babel/core@7.28.3)(css-loader@7.1.4(webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4(webpack@5.104.1))))(typescript@5.9.2)(vite@6.4.2(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3))(vue@2.7.15)
       '@vitejs/plugin-vue2':
         specifier: 2.3.1
         version: 2.3.1(vite@6.4.2(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3))(vue@2.7.15)
@@ -5551,19 +5552,6 @@ packages:
     resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
     engines: {node: '>= 10.13.0'}
 
-  semver@5.7.2:
-    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
-    hasBin: true
-
-  semver@6.3.1:
-    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
-    hasBin: true
-
-  semver@7.7.2:
-    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.7.3:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
     engines: {node: '>=10'}
@@ -6165,8 +6153,8 @@ packages:
   vue-component-type-helpers@2.2.12:
     resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
 
-  vue-component-type-helpers@3.3.2:
-    resolution: {integrity: sha512-l4Z2Y34m7nFMlx8vrslJaVtXxUpzgDMSESC7TakG/c5kwjYT/do+E0NcT2/vWDzaoIhsShg/2OKwX7Q4nbzC0g==}
+  vue-component-type-helpers@3.3.5:
+    resolution: {integrity: sha512-Fe1jyPJoUGpJOYKOri44jduR7My4yYINOMJISuMAbmrs+L5LbIDUc8NTWZYY3EJLK0yPLuCmcd5zoCsE4k2/KA==}
 
   vue-docgen-api@4.79.2:
     resolution: {integrity: sha512-n9ENAcs+40awPZMsas7STqjkZiVlIjxIKgiJr5rSohDP0/JCrD9VtlzNojafsA1MChm/hz2h3PDtUedx3lbgfA==}
@@ -6458,7 +6446,7 @@ snapshots:
       debug: 4.4.1
       gensync: 1.0.0-beta.2
       json5: 2.2.3
-      semver: 6.3.1
+      semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
 
@@ -6488,7 +6476,7 @@ snapshots:
       '@babel/helper-validator-option': 7.27.1
       browserslist: 4.25.3
       lru-cache: 5.1.1
-      semver: 6.3.1
+      semver: 7.7.3
 
   '@babel/helper-create-class-features-plugin@7.28.3(@babel/core@7.28.3)':
     dependencies:
@@ -6499,7 +6487,7 @@ snapshots:
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.3)
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
       '@babel/traverse': 7.28.3
-      semver: 6.3.1
+      semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
 
@@ -6508,7 +6496,7 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-annotate-as-pure': 7.27.3
       regexpu-core: 6.2.0
-      semver: 6.3.1
+      semver: 7.7.3
 
   '@babel/helper-define-polyfill-provider@0.6.5(@babel/core@7.28.3)':
     dependencies:
@@ -7120,7 +7108,7 @@ snapshots:
       babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.28.3)
       babel-plugin-polyfill-regenerator: 0.6.5(@babel/core@7.28.3)
       core-js-compat: 3.45.1
-      semver: 6.3.1
+      semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
 
@@ -8056,7 +8044,7 @@ snapshots:
       detect-newline: 3.1.0
       execa: 8.0.1
       release-it: 19.2.3(@types/node@24.13.2)
-      semver: 7.7.2
+      semver: 7.7.3
       url-join: 4.0.1
       validate-peer-dependencies: 1.2.0
       walk-sync: 2.2.0
@@ -8680,12 +8668,12 @@ snapshots:
       '@types/express': 4.17.23
       file-system-cache: 2.3.0
 
-  '@storybook/vue-vite@7.6.21(@babel/core@7.28.3)(css-loader@7.1.4(webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4)))(typescript@5.9.2)(vite@6.4.2(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3))(vue@2.7.15)':
+  '@storybook/vue-vite@7.6.21(@babel/core@7.28.3)(css-loader@7.1.4(webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4(webpack@5.104.1))))(typescript@5.9.2)(vite@6.4.2(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3))(vue@2.7.15)':
     dependencies:
       '@storybook/builder-vite': 7.6.21(typescript@5.9.2)(vite@6.4.2(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3))
       '@storybook/core-common': 7.6.21
       '@storybook/core-server': 7.6.21
-      '@storybook/vue': 7.6.21(@babel/core@7.28.3)(css-loader@7.1.4(webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4)))(vue@2.7.15)
+      '@storybook/vue': 7.6.21(@babel/core@7.28.3)(css-loader@7.1.4(webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4(webpack@5.104.1))))(vue@2.7.15)
       magic-string: 0.30.18
       vite: 6.4.2(@types/node@24.13.2)(jiti@2.6.1)(sass@1.101.0)(terser@5.43.1)(yaml@2.8.3)
       vue: 2.7.15
@@ -8733,7 +8721,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.3.7(typescript@5.9.2)
-      vue-component-type-helpers: 3.3.7
+      vue-component-type-helpers: 3.3.5
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -8750,9 +8738,9 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.3.7(typescript@5.9.2)
-      vue-component-type-helpers: 3.3.7
+      vue-component-type-helpers: 3.3.5
 
-  '@storybook/vue@7.6.21(@babel/core@7.28.3)(css-loader@7.1.4(webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4)))(vue@2.7.15)':
+  '@storybook/vue@7.6.21(@babel/core@7.28.3)(css-loader@7.1.4(webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4(webpack@5.104.1))))(vue@2.7.15)':
     dependencies:
       '@babel/core': 7.28.3
       '@storybook/client-logger': 7.6.21
@@ -8761,7 +8749,7 @@ snapshots:
       '@storybook/global': 5.0.0
       '@storybook/preview-api': 7.6.21
       '@storybook/types': 7.6.21
-      css-loader: 7.1.4(webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4))
+      css-loader: 7.1.4(webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4(webpack@5.104.1)))
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 2.7.15
@@ -9595,7 +9583,7 @@ snapshots:
       handlebars: 4.7.9
       node-fetch: 2.7.0
       parse-github-url: 1.0.3
-      semver: 7.7.2
+      semver: 7.7.3
     transitivePeerDependencies:
       - encoding
 
@@ -9624,7 +9612,7 @@ snapshots:
       '@babel/compat-data': 7.28.0
       '@babel/core': 7.28.3
       '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.3)
-      semver: 6.3.1
+      semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
 
@@ -9956,7 +9944,7 @@ snapshots:
 
   crypto-random-string@2.0.0: {}
 
-  css-loader@7.1.4(webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4)):
+  css-loader@7.1.4(webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4(webpack@5.104.1))):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.10)
       postcss: 8.5.10
@@ -9967,7 +9955,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.3
     optionalDependencies:
-      webpack: 5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4)
+      webpack: 5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4(webpack@5.104.1))
 
   css-loader@7.1.4(webpack@5.104.1):
     dependencies:
@@ -10455,7 +10443,7 @@ snapshots:
       natural-compare: 1.4.0
       nth-check: 2.1.1
       postcss-selector-parser: 6.1.2
-      semver: 7.7.2
+      semver: 7.7.3
       vue-eslint-parser: 10.1.3(eslint@9.39.2(jiti@2.6.1))
       xml-name-validator: 4.0.0
 
@@ -11149,7 +11137,7 @@ snapshots:
       '@babel/parser': 7.28.3
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 6.3.1
+      semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
 
@@ -11426,11 +11414,11 @@ snapshots:
   make-dir@2.1.0:
     dependencies:
       pify: 4.0.1
-      semver: 5.7.2
+      semver: 7.7.3
 
   make-dir@3.1.0:
     dependencies:
-      semver: 6.3.1
+      semver: 7.7.3
 
   make-dir@4.0.0:
     dependencies:
@@ -11584,7 +11572,7 @@ snapshots:
     dependencies:
       hosted-git-info: 2.8.9
       resolve: 1.22.10
-      semver: 5.7.2
+      semver: 7.7.3
       validate-npm-package-license: 3.0.4
 
   normalize-path@3.0.0: {}
@@ -12377,12 +12365,6 @@ snapshots:
       ajv-formats: 2.1.1(ajv@8.18.0)
       ajv-keywords: 5.1.0(ajv@8.18.0)
 
-  semver@5.7.2: {}
-
-  semver@6.3.1: {}
-
-  semver@7.7.2: {}
-
   semver@7.7.3: {}
 
   send@0.19.0:
@@ -12637,14 +12619,14 @@ snapshots:
       type-fest: 0.16.0
       unique-string: 2.0.0
 
-  terser-webpack-plugin@5.3.16(esbuild@0.25.0)(webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4)):
+  terser-webpack-plugin@5.3.16(esbuild@0.25.0)(webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4(webpack@5.104.1))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.30
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       serialize-javascript: 7.0.5
       terser: 5.43.1
-      webpack: 5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4)
+      webpack: 5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4(webpack@5.104.1))
     optionalDependencies:
       esbuild: 0.25.0
     optional: true
@@ -12872,7 +12854,7 @@ snapshots:
   validate-peer-dependencies@1.2.0:
     dependencies:
       resolve-package-path: 3.1.0
-      semver: 7.7.2
+      semver: 7.7.3
 
   vary@1.1.2: {}
 
@@ -12967,7 +12949,7 @@ snapshots:
 
   vue-component-type-helpers@2.2.12: {}
 
-  vue-component-type-helpers@3.3.2: {}
+  vue-component-type-helpers@3.3.5: {}
 
   vue-docgen-api@4.79.2(vue@2.7.15):
     dependencies:
@@ -13010,7 +12992,7 @@ snapshots:
       espree: 10.4.0
       esquery: 1.6.0
       lodash: 4.18.0
-      semver: 7.7.2
+      semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
 
@@ -13031,7 +13013,7 @@ snapshots:
     dependencies:
       '@volar/typescript': 1.11.1
       '@vue/language-core': 1.8.27(typescript@5.9.2)
-      semver: 7.7.2
+      semver: 7.7.3
       typescript: 5.9.2
 
   vue-tsc@2.2.0(typescript@5.9.2):
@@ -13110,7 +13092,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4):
+  webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4(webpack@5.104.1)):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -13134,7 +13116,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.3.16(esbuild@0.25.0)(webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4))
+      terser-webpack-plugin: 5.3.16(esbuild@0.25.0)(webpack@5.104.1(esbuild@0.25.0)(webpack-cli@5.1.4(webpack@5.104.1)))
       watchpack: 2.4.4
       webpack-sources: 3.3.3
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,6 +36,7 @@ overrides:
   qs: 6.15.2
   rollup: 4.59.0
   send: 0.19.0
+  semver: 7.7.3
   serialize-javascript: 7.0.5
   serve-static: 1.16.0
   store2: 2.14.4
@@ -48,5 +49,9 @@ overrides:
   ws: 8.20.1
   yaml: 2.8.3
 
-onlyBuiltDependencies:
-  - esbuild
+trustPolicyExclude:
+  - 'detect-port@1.6.1'
+
+allowBuilds:
+  '@parcel/watcher': false
+  esbuild: true


### PR DESCRIPTION
Relates to N/A

## 📝 Description

- Upgrade Dart Sass to 1.101.0 and sass-loader to 17.0.0.
- Replace deprecated global `nth()` calls with `list.nth()`.
- Run CI on the latest LTS Node runtime required by sass-loader 17.
- Bump Lume packages to 1.12.4 and add the changelog entry.
- Resolve pnpm 11 trust-policy failures by consolidating transitive semver on provenance-backed 7.7.3.
- Add an exact trust-policy exception for the reviewed legacy `detect-port@1.6.1` package.
- Preserve generated Vue 2 and Vue 3 CSS byte-for-byte.

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

## 📝 Additional Information

Validation completed:

- Clean pnpm 11 install passes the configured corporate supply-chain policy
- `pnpm run build`
- 191 unit tests passed, 7 skipped
- ESLint completed with 0 errors (36 existing warnings)
- Prettier check passed for the edited workspace policy
- Sass 1.101 compilation passed with current deprecations treated as fatal
- Vue 3 Storybook build passed in an isolated path without the unrelated home Yarn PnP manifest
- Generated Vue 2 and Vue 3 `main.css` and `font.css` files remain byte-identical

The pnpm 11 `allowBuilds` migration preserves the existing esbuild approval and explicitly keeps `@parcel/watcher` build scripts disabled. No registry override or policy bypass was used.

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there is not already a PR that solves the problem the same way.
- [x] Provide a description that addresses what the PR is solving.
- [x] Run the relevant build, test, lint, formatting, and Sass validation checks.