### PR TITLE
🐛 Fix alluvial node column sort order

### DIFF
--- a/packages/lib/src/components/groups/lume-alluvial-group/composables/alluvial-graph.ts
+++ b/packages/lib/src/components/groups/lume-alluvial-group/composables/alluvial-graph.ts
@@ -23,7 +23,7 @@ const EMPTY_GRAPH = {
 } as SankeyGraph;
 
 function getColumnByNode(node: SankeyNode, columns: Array<Array<SankeyNode>>) {
-  return columns.find((column) => column.every((n) => n.x0 === node.x0));
+  return columns.find((column) => column.every((n) => n.depth === node.depth));
 }
 
 export function useAlluvialGraph(
@@ -78,8 +78,8 @@ export function useAlluvialGraph(
   });
 
   const columns = computed<Array<Array<SankeyNode>>>(() => {
-    return sankeyGraph.value?.nodes.reduce(
-      (cols: Array<Array<SankeyNode>>, node: SankeyNode) => {
+    return sankeyGraph.value?.nodes
+      .reduce((cols: Array<Array<SankeyNode>>, node: SankeyNode) => {
         const existingColumn = getColumnByNode(node, cols);
         if (existingColumn) {
           existingColumn.push(node);
@@ -88,9 +88,8 @@ export function useAlluvialGraph(
           cols.push([node]);
         }
         return cols;
-      },
-      []
-    );
+      }, [])
+      .sort((a, b) => a[0].depth - b[0].depth);
   });
 
   function computeStaticNodePosition(node: SankeyNode) {


### PR DESCRIPTION

## 📝 Description

Fixes the alluvial node column sort order (before it wasn't always following the depth)

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

## 📝 Additional Information

- This was causing wrong node column header positions

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
