### PR TITLE
✨ Add alluvial node label and header alignment

### DIFF
--- a/packages/lib/src/components/charts/lume-alluvial-diagram/defaults.ts
+++ b/packages/lib/src/components/charts/lume-alluvial-diagram/defaults.ts
@@ -15,6 +15,8 @@ export const options: AlluvialDiagramOptions = {
   withLegend: false,
 
   // Alluvial options
+  alignFirstNodeLabels: 'left',
+  alignLastNodeLabels: 'right',
   gradient: false,
   highlightedElements: 'closest',
   nodePadding: 16,

--- a/packages/lib/src/components/charts/lume-alluvial-diagram/lume-alluvial-diagram.stories.ts
+++ b/packages/lib/src/components/charts/lume-alluvial-diagram/lume-alluvial-diagram.stories.ts
@@ -92,6 +92,27 @@ export const MultipleLevels: Story = {
   },
 };
 
+export const InnerAlignedNodeLabels: Story = {
+  render: ({ args }) => ({
+    components: { LumeAlluvialDiagram },
+    setup() {
+      return { args, captureAction };
+    },
+    template: `<div :style="{ width: args.width + 'px', height: args.height + 'px' }">
+    <lume-alluvial-diagram v-bind="args" ${actionEventHandlerTemplate} />
+  </div>`,
+  }),
+  args: {
+    ...DATASETS.Basic,
+    title: 'Students performance in science exam',
+    options: {
+      alignFirstNodeLabels: 'right',
+      alignLastNodeLabels: 'left',
+      nodeLabelMaxWidth: 100,
+    },
+  },
+};
+
 export const MultipleLevelsWithColorDerivationFromIncomingLinks: Story = {
   render: ({ args }) => ({
     components: { LumeAlluvialDiagram },

--- a/packages/lib/src/components/groups/lume-alluvial-group/components/lume-alluvial-node-header/README.md
+++ b/packages/lib/src/components/groups/lume-alluvial-group/components/lume-alluvial-node-header/README.md
@@ -36,7 +36,8 @@ To overwrite the default node header, add your content to the respective `node-h
 
 ### Props
 
-| Name | Type     | Default  | Description                            |
-| ---- | -------- | -------- | -------------------------------------- |
-| `x`  | `number` | Required | The horizontal position of the header. |
-| `y`  | `number` | Required | The vertical position of the header.   |
+| Name    | Type                            | Default    | Description                                                   |
+| ------- | ------------------------------- | ---------- | ------------------------------------------------------------- |
+| `align` | `'left' \| 'center' \| 'right'` | `'center'` | The horizontal alignment of the header text, relative to `x`. |
+| `x`     | `number`                        | Required   | The horizontal position of the header.                        |
+| `y`     | `number`                        | Required   | The vertical position of the header.                          |

--- a/packages/lib/src/components/groups/lume-alluvial-group/components/lume-alluvial-node-header/lume-alluvial-node-header.vue
+++ b/packages/lib/src/components/groups/lume-alluvial-group/components/lume-alluvial-node-header/lume-alluvial-node-header.vue
@@ -6,6 +6,9 @@
     <text
       ref="textRef"
       class="lume-alluvial-group__node-header lume-typography--caption"
+      :class="{
+        [`lume-alluvial-group__node-header--${align}`]: align !== 'center',
+      }"
     >
       <slot />
     </text>
@@ -16,20 +19,35 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref } from 'vue';
+import { computed, PropType, ref } from 'vue';
 
-defineProps({
+import type { AlluvialNodeHeaderAlignment } from '@/types/alluvial';
+
+const props = defineProps({
+  align: {
+    type: String as PropType<AlluvialNodeHeaderAlignment>,
+    default: 'center',
+  },
   x: { type: Number, required: true },
   y: { type: Number, required: true },
 });
 
 const textRef = ref<SVGGraphicsElement>(null);
 
+const textWidth = computed(() => textRef.value?.getBBox().width ?? 0);
+
+// Horizontal offset of the text's left edge, which depends on its alignment
+const textStart = computed(() => {
+  if (props.align === 'left') return 0;
+  if (props.align === 'right') return -textWidth.value;
+  return -textWidth.value / 2;
+});
+
 const beforeTransform = computed(
-  () => textRef.value && `translate(${-textRef.value.getBBox().width / 2}, 0)`
+  () => textRef.value && `translate(${textStart.value}, 0)`
 );
 const afterTransform = computed(
-  () => textRef.value && `translate(${textRef.value.getBBox().width / 2}, 0)`
+  () => textRef.value && `translate(${textStart.value + textWidth.value}, 0)`
 );
 </script>
 

--- a/packages/lib/src/components/groups/lume-alluvial-group/helpers.ts
+++ b/packages/lib/src/components/groups/lume-alluvial-group/helpers.ts
@@ -14,6 +14,7 @@ import type {
   SankeyLinkProps,
   SankeyNodeProps,
 } from '@/types/alluvial';
+import type { AlluvialDiagramOptions } from '@/types/options';
 
 const TRANSITION_DURATION = 200;
 
@@ -46,17 +47,67 @@ export function isSankeyNode(
   );
 }
 
+/**
+ * Gets the layer (column index) of the diagram's last node column.
+ *
+ * @param nodes The graph nodes.
+ * @returns The last layer index.
+ */
+export function getLastNodeLayer(
+  nodes: Array<SankeyNode<SankeyNodeProps, SankeyLinkProps>>
+) {
+  return Math.max(
+    ...nodes
+      .filter((node) => node.parentNodeId == null) // Sub-nodes sit between columns
+      .map(({ layer }) => layer)
+  );
+}
+
+function isFirstColumnNode(node: SankeyNode<SankeyNodeProps, SankeyLinkProps>) {
+  return node.layer === 0;
+}
+
+function isLastColumnNode(
+  node: SankeyNode<SankeyNodeProps, SankeyLinkProps>,
+  lastNodeLayer: number
+) {
+  return node.parentNodeId == null && node.layer === lastNodeLayer;
+}
+
+/**
+ * Whether a node's label is rendered before (to the left of) its block. Only
+ * the first and last columns are configurable; all others are rendered after.
+ *
+ * @param node A sankey node.
+ * @param options The chart options, holding the configured label alignments.
+ * @param lastNodeLayer The layer of the diagram's last node column.
+ * @returns `true` if the label should be rendered to the left of the node.
+ */
+export function isNodeLabelBeforeNode(
+  node: SankeyNode<SankeyNodeProps, SankeyLinkProps>,
+  options: AlluvialDiagramOptions,
+  lastNodeLayer: number
+) {
+  if (isFirstColumnNode(node)) return options.alignFirstNodeLabels !== 'right';
+  if (isLastColumnNode(node, lastNodeLayer))
+    return options.alignLastNodeLabels === 'left';
+  return false;
+}
+
 export function getLabelSizes(
   graph: SankeyGraph<SankeyNodeProps, SankeyLinkProps>,
-  nodeTextElements: Array<SVGTextElement>
+  nodeTextElements: Array<SVGTextElement>,
+  options: AlluvialDiagramOptions
 ) {
   if (!nodeTextElements) return;
 
+  const lastNodeLayer = getLastNodeLayer(graph.nodes);
+
   const startNodeIDs = graph.nodes
-    .filter((node) => node.targetLinks.length === 0)
+    .filter((node) => isFirstColumnNode(node))
     .map((n) => `${n.id}`);
   const endNodeIDs = graph.nodes
-    .filter((node) => node.sourceLinks.length === 0)
+    .filter((node) => isLastColumnNode(node, lastNodeLayer))
     .map((n) => `${n.id}`);
 
   const maxStartNodeWidth = nodeTextElements
@@ -72,17 +123,21 @@ export function getLabelSizes(
       -Infinity
     );
 
+  // Labels rendered towards the inside of the diagram are drawn over the links, so they don't need a margin
   return {
-    left: maxStartNodeWidth,
+    left: options.alignFirstNodeLabels === 'right' ? 0 : maxStartNodeWidth,
     top: 0,
-    right: maxEndNodeWidth,
+    right: options.alignLastNodeLabels === 'left' ? 0 : maxEndNodeWidth,
     bottom: 0,
   };
 }
 
 export function getNodeBlockAttributes(
-  nodes: Array<SankeyNode<SankeyNodeProps, SankeyLinkProps>>
+  nodes: Array<SankeyNode<SankeyNodeProps, SankeyLinkProps>>,
+  options: AlluvialDiagramOptions
 ): Array<NodeBlock> {
+  const lastNodeLayer = getLastNodeLayer(nodes);
+
   return nodes.map((node) => {
     const isMinimumHeight = node.y1 - node.y0 < NODE_MINIMUM_HEIGHT;
     return {
@@ -91,10 +146,9 @@ export function getNodeBlockAttributes(
       width: node.x1 - node.x0,
       height: isMinimumHeight ? NODE_MINIMUM_HEIGHT : node.y1 - node.y0,
       textTransform: {
-        x:
-          node.depth > 0
-            ? node.x1 + NODE_LABEL_PADDING
-            : node.x0 - NODE_LABEL_PADDING,
+        x: isNodeLabelBeforeNode(node, options, lastNodeLayer)
+          ? node.x0 - NODE_LABEL_PADDING
+          : node.x1 + NODE_LABEL_PADDING,
         y: (node.y1 + node.y0) / 2,
       },
       node,

--- a/packages/lib/src/components/groups/lume-alluvial-group/lume-alluvial-group.spec.ts
+++ b/packages/lib/src/components/groups/lume-alluvial-group/lume-alluvial-group.spec.ts
@@ -1,4 +1,12 @@
-import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from 'vitest';
 import { nextTick, reactive } from 'vue';
 import { mount } from '@vue/test-utils';
 
@@ -6,9 +14,18 @@ import LumeAlluvialGroup from './lume-alluvial-group.vue';
 
 import { options as defaultOptions } from '@/components/charts/lume-alluvial-diagram/defaults';
 import { alluvialData } from '@test/unit/alluvial-mock-data';
+import { NODE_LABEL_PADDING } from './constants';
 
 const CONTAINER_SIZE = { width: 1000, height: 480 };
 const NODE_HEADERS = ['first', 'second', 'third', 'fourth'];
+
+const FIRST_COLUMN_NODE_ID = 'sourceA';
+const MIDDLE_COLUMN_NODE_ID = 'flowA';
+const LAST_COLUMN_NODE_ID = 'resultA';
+
+const LEFT_LABEL_CLASS = 'lume-alluvial-group__node-text--left';
+const LEFT_HEADER_CLASS = 'lume-alluvial-group__node-header--left';
+const RIGHT_HEADER_CLASS = 'lume-alluvial-group__node-header--right';
 
 const PARENT_NODE_ID = 'flowB';
 const SUB_NODE_IDS = ['subA', 'subB', 'subC'];
@@ -87,19 +104,63 @@ async function expandParentNode(wrapper) {
   await wrapper.find(`[data-id="${PARENT_NODE_ID}"]`).trigger('click');
 }
 
-function getNodeClasses(wrapper, id: string) {
-  const nodeText = wrapper.find(
-    `.lume-alluvial-group__node-text[data-id="${id}"]`
+function getColumnPositions(wrapper) {
+  const positions = Object.values(getNodeGeometry(wrapper)).map(
+    ({ x }: { x: number }) => x
   );
 
-  return nodeText.element.parentElement.parentElement.getAttribute('class');
+  return [...new Set(positions)].sort((a, b) => a - b);
+}
+
+function getNodeLabel(wrapper, id: string) {
+  return wrapper.find(`.lume-alluvial-group__node-text[data-id="${id}"]`);
+}
+
+function getNodeClasses(wrapper, id: string) {
+  return getNodeLabel(
+    wrapper,
+    id
+  ).element.parentElement.parentElement.getAttribute('class');
+}
+
+function getNodeHeader(wrapper, index: number) {
+  const header = wrapper.findAll('text.lume-alluvial-group__node-header')[
+    index
+  ];
+  const [, x] = header.element.parentElement
+    .getAttribute('transform')
+    .match(/translate\((-?[\d.]+)/);
+
+  return { x: Number(x), classes: header.classes() };
+}
+
+function getNodeLabelX(wrapper, id: string) {
+  const [, x] = getNodeLabel(wrapper, id)
+    .attributes('transform')
+    .match(/translate\((-?[\d.]+)/);
+
+  return Number(x);
+}
+
+function expectLabelBeforeNode(wrapper, id: string, geometry) {
+  expect(getNodeLabelX(wrapper, id)).toBe(geometry[id].x - NODE_LABEL_PADDING);
+  expect(getNodeLabel(wrapper, id).classes()).toContain(LEFT_LABEL_CLASS);
+}
+
+function expectLabelAfterNode(wrapper, id: string, geometry) {
+  expect(getNodeLabelX(wrapper, id)).toBe(
+    geometry[id].x + geometry[id].width + NODE_LABEL_PADDING
+  );
+  expect(getNodeLabel(wrapper, id).classes()).not.toContain(LEFT_LABEL_CLASS);
 }
 
 describe('lume-alluvial-group.vue', () => {
+  let labelWidth = 0;
+
   // jsdom doesn't implement SVG measurement, used for the diagram's label margins
   beforeAll(() => {
     Object.assign(Element.prototype, {
-      getBBox: () => ({ x: 0, y: 0, width: 0, height: 0 }),
+      getBBox: () => ({ x: 0, y: 0, width: labelWidth, height: 0 }),
     });
   });
 
@@ -286,6 +347,114 @@ describe('lume-alluvial-group.vue', () => {
           true
         )
       );
+    });
+  });
+
+  describe('node label alignment', () => {
+    const LABEL_WIDTH = 40;
+
+    beforeEach(() => {
+      labelWidth = LABEL_WIDTH;
+    });
+
+    afterEach(() => {
+      labelWidth = 0;
+    });
+
+    test('should render the first column labels before and the last column ones after their node by default', async () => {
+      const wrapper = await mountGroup();
+      const geometry = getNodeGeometry(wrapper);
+
+      expectLabelBeforeNode(wrapper, FIRST_COLUMN_NODE_ID, geometry);
+      expectLabelAfterNode(wrapper, LAST_COLUMN_NODE_ID, geometry);
+    });
+
+    test('should render the first column labels after their node when aligned right', async () => {
+      const wrapper = await mountGroup(alluvialData, {
+        alignFirstNodeLabels: 'right',
+      });
+      const geometry = getNodeGeometry(wrapper);
+
+      expectLabelAfterNode(wrapper, FIRST_COLUMN_NODE_ID, geometry);
+      expectLabelAfterNode(wrapper, LAST_COLUMN_NODE_ID, geometry);
+    });
+
+    test('should render the last column labels before their node when aligned left', async () => {
+      const wrapper = await mountGroup(alluvialData, {
+        alignLastNodeLabels: 'left',
+      });
+      const geometry = getNodeGeometry(wrapper);
+
+      expectLabelBeforeNode(wrapper, FIRST_COLUMN_NODE_ID, geometry);
+      expectLabelBeforeNode(wrapper, LAST_COLUMN_NODE_ID, geometry);
+    });
+
+    test('should keep the middle column labels after their node', async () => {
+      const wrapper = await mountGroup(alluvialData, {
+        alignFirstNodeLabels: 'right',
+        alignLastNodeLabels: 'left',
+      });
+
+      expectLabelAfterNode(
+        wrapper,
+        MIDDLE_COLUMN_NODE_ID,
+        getNodeGeometry(wrapper)
+      );
+    });
+
+    test('should only reserve horizontal space for the labels rendered outside the columns', async () => {
+      const defaultColumns = getColumnPositions(await mountGroup());
+      const innerColumns = getColumnPositions(
+        await mountGroup(alluvialData, {
+          alignFirstNodeLabels: 'right',
+          alignLastNodeLabels: 'left',
+        })
+      );
+      const lastColumnEnd = (positions: Array<number>) =>
+        positions[positions.length - 1] + defaultOptions.nodeWidth;
+
+      expect(defaultColumns[0]).toBe(LABEL_WIDTH);
+      expect(lastColumnEnd(defaultColumns)).toBe(
+        CONTAINER_SIZE.width - LABEL_WIDTH
+      );
+
+      expect(innerColumns[0]).toBe(0);
+      expect(lastColumnEnd(innerColumns)).toBe(CONTAINER_SIZE.width);
+    });
+
+    test('should center the node headers on their column by default', async () => {
+      const wrapper = await mountGroup();
+      const columns = getColumnPositions(wrapper);
+      const center = (x: number) => x + defaultOptions.nodeWidth / 2;
+
+      expect(getNodeHeader(wrapper, 0)).toEqual({
+        x: center(columns[0]),
+        classes: expect.not.arrayContaining([
+          LEFT_HEADER_CLASS,
+          RIGHT_HEADER_CLASS,
+        ]),
+      });
+      expect(getNodeHeader(wrapper, NODE_HEADERS.length - 1).x).toBe(
+        center(columns[columns.length - 1])
+      );
+    });
+
+    test('should align the node headers to the outer edge of the columns rendering their labels inwards', async () => {
+      const wrapper = await mountGroup(alluvialData, {
+        alignFirstNodeLabels: 'right',
+        alignLastNodeLabels: 'left',
+      });
+      const columns = getColumnPositions(wrapper);
+      const firstHeader = getNodeHeader(wrapper, 0);
+      const lastHeader = getNodeHeader(wrapper, NODE_HEADERS.length - 1);
+
+      expect(firstHeader.x).toBe(columns[0]);
+      expect(firstHeader.classes).toContain(LEFT_HEADER_CLASS);
+
+      expect(lastHeader.x).toBe(
+        columns[columns.length - 1] + defaultOptions.nodeWidth
+      );
+      expect(lastHeader.classes).toContain(RIGHT_HEADER_CLASS);
     });
   });
 });

--- a/packages/lib/src/components/groups/lume-alluvial-group/lume-alluvial-group.vue
+++ b/packages/lib/src/components/groups/lume-alluvial-group/lume-alluvial-group.vue
@@ -8,11 +8,13 @@
       <template v-for="(header, index) in nodeHeaders">
         <slot
           :name="`node-header-${index}`"
+          :align="header.align"
           :x="header.x"
           :y="-computedNodeHeaderPadding"
         >
           <lume-alluvial-node-header
             :key="`header_${header.x}`"
+            :align="header.align"
             :x="header.x"
             :y="-computedNodeHeaderPadding"
           >
@@ -154,7 +156,9 @@
           ref="nodeTextRefs"
           class="lume-alluvial-group__node-text lume-typography--caption"
           :class="{
-            'lume-alluvial-group__node-text--left': block.node.depth === 0,
+            'lume-alluvial-group__node-text--left': isLabelBeforeNode(
+              block.node
+            ),
           }"
           :transform="`translate(${block.textTransform.x},${block.textTransform.y})`"
           :data-id="block.node.id"
@@ -172,7 +176,7 @@
           >
             <lume-alluvial-node-label
               :bottom="options.switchText"
-              :left="block.node.depth === 0"
+              :left="isLabelBeforeNode(block.node)"
               :max-width="options.nodeLabelMaxWidth"
               @lume__internal--node-resize="updateMargins"
             >
@@ -218,15 +222,18 @@ import {
 } from './constants';
 import {
   getLabelSizes,
+  getLastNodeLayer,
   getLinkById,
   getLinkPathAttributes,
   getNodeBlockAttributes,
   getNodeById,
+  isNodeLabelBeforeNode,
 } from './helpers';
 
 import type { AlluvialDiagramOptions } from '@/types/options';
 import type {
   AlluvialNode,
+  AlluvialNodeHeaderAlignment,
   LinkPath,
   NodeBlock,
   SankeyLink,
@@ -283,11 +290,33 @@ const hoveredNodeIds = computed(() =>
   Object.keys(highlightedElements.value.nodes)
 );
 
-const nodeColumnPositions = computed<Array<number>>(() => {
+const lastNodeLayer = computed(() =>
+  graph.value?.nodes?.length ? getLastNodeLayer(graph.value.nodes) : 0
+);
+
+// Headers are centered on their column, except when the column's labels are
+// rendered inwards, where they follow the column's outer edge to stay in bounds
+const nodeColumnPositions = computed<
+  Array<{ x: number; align: AlluvialNodeHeaderAlignment }>
+>(() => {
   if (!columns.value) return [];
-  return columns.value.map(
-    (column) => column[0].x0 + options.value.nodeWidth / 2
-  );
+
+  const lastColumnIndex = columns.value.length - 1;
+
+  return columns.value.map(([{ x0, x1 }], index) => {
+    if (index === 0 && options.value.alignFirstNodeLabels === 'right') {
+      return { x: x0, align: 'left' };
+    }
+
+    if (
+      index === lastColumnIndex &&
+      options.value.alignLastNodeLabels === 'left'
+    ) {
+      return { x: x1, align: 'right' };
+    }
+
+    return { x: (x0 + x1) / 2, align: 'center' };
+  });
 });
 
 const nodeHeaders = computed(() => {
@@ -297,7 +326,7 @@ const nodeHeaders = computed(() => {
     .slice(0, nodeColumnPositions.value.length) // Match column/header array lengths
     .map((header, index) => ({
       label: header,
-      x: nodeColumnPositions.value[index],
+      ...nodeColumnPositions.value[index],
     }));
 });
 
@@ -418,6 +447,10 @@ function isLinkFocused(id: string) {
   );
 }
 
+function isLabelBeforeNode(node: NodeBlock['node']) {
+  return isNodeLabelBeforeNode(node, options.value, lastNodeLayer.value);
+}
+
 function shouldDeriveNodeColorFromIncomingLinks(block: NodeBlock) {
   return !block.node.color && block.node.deriveColorFromIncomingLinks;
 }
@@ -468,13 +501,17 @@ function getSubNodesDerivingColorFromIncomingLinks(nodeId: number | string) {
 }
 
 function updateMargins() {
-  const labelSizes = getLabelSizes(graph.value, nodeTextRefs.value);
+  const labelSizes = getLabelSizes(
+    graph.value,
+    nodeTextRefs.value,
+    options.value
+  );
   updateExtents(labelSizes);
 }
 
 // Render nodes/paths whenever the SankeyGraph changes
 watch(graph, (newGraph) => {
-  nodeBlocks.value = getNodeBlockAttributes(newGraph.nodes);
+  nodeBlocks.value = getNodeBlockAttributes(newGraph.nodes, options.value);
   linkPaths.value = getLinkPathAttributes(newGraph.links).reverse(); // Reverse order of link rendering so that the furthermost links are renderd on top
 
   // Handle initial hoveredElement from props
@@ -494,6 +531,12 @@ watch([props.containerSize, nodeTextRefs], () => {
     updateMargins();
   }
 });
+
+// The label alignment changes both the label offsets and the diagram's horizontal margins
+watch(
+  () => [options.value.alignFirstNodeLabels, options.value.alignLastNodeLabels],
+  updateMargins
+);
 
 watch(() => props.hoveredElementId, handleExternalHover);
 </script>

--- a/packages/lib/src/components/groups/lume-alluvial-group/styles.scss
+++ b/packages/lib/src/components/groups/lume-alluvial-group/styles.scss
@@ -117,6 +117,16 @@ $lume-alluvial-link-opacity-focused: 0.5 !default;
     text-anchor: middle;
     text-align: center;
     cursor: default;
+
+    &--left {
+      text-anchor: start;
+      text-align: left;
+    }
+
+    &--right {
+      text-anchor: end;
+      text-align: right;
+    }
   }
 }
 

--- a/packages/lib/src/types/alluvial.ts
+++ b/packages/lib/src/types/alluvial.ts
@@ -10,6 +10,10 @@ import type { Color } from '@/types/utils';
 
 export type AlluvialNodeId = number | string;
 
+export type AlluvialNodeLabelAlignment = 'left' | 'right';
+
+export type AlluvialNodeHeaderAlignment = AlluvialNodeLabelAlignment | 'center';
+
 interface AlluvialNodeTarget {
   node: string;
   value: number;

--- a/packages/lib/src/types/options.ts
+++ b/packages/lib/src/types/options.ts
@@ -1,4 +1,5 @@
 import type {
+  AlluvialNodeLabelAlignment,
   GetHighlightedElementsFunction,
   SankeyLink,
   SankeyLinkProps,
@@ -70,6 +71,8 @@ export interface LineChartOptions extends ChartOptions {
 }
 
 export interface AlluvialDiagramOptions extends ChartOptions {
+  alignFirstNodeLabels?: AlluvialNodeLabelAlignment; // Side where the first column's node labels are rendered
+  alignLastNodeLabels?: AlluvialNodeLabelAlignment; // Side where the last column's node labels are rendered
   gradient?: boolean;
   highlightedElements?: 'full' | 'closest' | GetHighlightedElementsFunction;
   nodeAlign?: (node: SankeyNode<unknown, unknown>, n: number) => number;


### PR DESCRIPTION
Relates to #

> [!NOTE]
> Stacked on top of #668 — please review/merge that one first. This PR targets `feat/alluvial-expandable-nodes` and will be retargeted to `main` once #668 is merged.

## 📝 Description

Adds two alluvial options to control on which side the outer node labels are rendered:

| Option | Type | Default |
| --- | --- | --- |
| `alignFirstNodeLabels` | `'left' \| 'right'` | `'left'` |
| `alignLastNodeLabels` | `'left' \| 'right'` | `'right'` |

Setting the first column to `'right'` (or the last column to `'left'`) renders those labels over the links, towards the inside of the diagram, so that column sits flush against the container edge. The horizontal label margin is only reserved on the side where labels point outwards. Middle columns always render their labels after the node.

Node headers follow the same alignment: a column whose labels point inwards has its header anchored to the column's outer edge instead of centered, so it no longer overflows the container.

## 💥 Is this a breaking change (Yes/No):

- [x] No
- [ ] Yes (please describe the impact and migration path for existing Lume users)

## 📝 Additional Information

- The first/last columns are now determined strictly by column (`layer`), for both the label side and the label margins.
- `LumeAlluvialNodeHeader` takes a new `align` prop (`'left' | 'center' | 'right'`, default `'center'`), also exposed on the `node-header-{index}` slot. Its `before`/`after` slot offsets are now derived from the text's left edge, so they stay correct for every anchor.
- New `InnerAlignedNodeLabels` story.

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/Adyen/lume/blob/main/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
